### PR TITLE
[chore] upload.sh를 Makefile로 대체

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+.PHONY: help install test build upload
+
+VENV := .venv
+
+# Default target
+help:
+	@echo "Korea Investment Stock - Makefile"
+	@echo ""
+	@echo "Available targets:"
+	@echo "  install    Install package in editable mode"
+	@echo "  test       Run all tests"
+	@echo "  build      Build distribution packages"
+	@echo "  upload     Upload package to PyPI"
+
+# Install package in editable mode
+install:
+	@test -d $(VENV) || python3 -m venv $(VENV)
+	@source $(VENV)/bin/activate && pip install -e .
+
+# Run all tests
+test:
+	@test -d $(VENV) || python3 -m venv $(VENV)
+	@source $(VENV)/bin/activate && pytest
+
+# Build distribution packages
+build:
+	@test -d $(VENV) || python3 -m venv $(VENV)
+	@rm -rf build/ dist/ *.egg-info
+	@source $(VENV)/bin/activate && python -m build
+
+# Upload to PyPI
+upload:
+	@test -d $(VENV) || python3 -m venv $(VENV)
+	@source $(VENV)/bin/activate && python -m twine upload dist/*


### PR DESCRIPTION
## 변경 사항

upload.sh 스크립트를 Makefile로 대체하여 더 표준적이고 간편한 빌드 환경을 제공합니다.

## 주요 개선 사항

### 1. 가상환경 자동 관리
- `.venv` 폴더가 없으면 자동 생성
- 모든 Python 명령 실행 시 `source .venv/bin/activate` 자동 실행
- 가상환경 격리 보장

### 2. 간소화된 인터페이스
핵심 기능만 유지하여 사용성 개선:
- `make install` - 패키지 설치
- `make test` - 테스트 실행
- `make build` - 빌드 (기존 upload.sh의 build 부분)
- `make upload` - PyPI 업로드 (기존 upload.sh의 upload 부분)

### 3. 불필요한 기능 제거
- install-dev, test-verbose, test-integration
- clean, clean-all, all 타겟 제거
- 35줄로 간소화 (기존 90줄 대비 61% 감소)

## 사용 예시

```bash
# 처음 시작 (.venv 자동 생성 + 설치)
make install

# 테스트 실행
make test

# PyPI 릴리스 (기존 ./upload.sh 대체)
make build
make upload
```

## 테스트

- [x] .venv 자동 생성 확인
- [x] make install 정상 동작
- [x] make help 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)