### PR TITLE
[feat] Add automated PR comments for unit test results

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,9 +27,47 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Run unit tests
+        id: pytest
         run: |
           pytest korea_investment_stock/ -v \
             --ignore=korea_investment_stock/test_korea_investment_stock.py \
             --ignore=korea_investment_stock/test_integration_us_stocks.py \
             --ignore=korea_investment_stock/cache/test_cached_integration.py \
-            -k "not (Redis or redis_storage or TestTokenStorageIntegration)"
+            -k "not (Redis or redis_storage or TestTokenStorageIntegration)" \
+            > test-output.txt 2>&1
+        continue-on-error: true
+
+      - name: Comment test results on PR
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const output = fs.readFileSync('test-output.txt', 'utf8');
+
+            // Extract summary from pytest output
+            const lines = output.split('\n');
+            const summaryLine = lines.find(line => line.includes('passed') || line.includes('failed'));
+            const lastLines = lines.slice(-15).join('\n');
+
+            const comment = `## 🧪 Unit Test Results
+
+            \`\`\`
+            ${summaryLine || 'Test results not found'}
+            \`\`\`
+
+            <details>
+            <summary>📋 Test Output (last 15 lines)</summary>
+
+            \`\`\`
+            ${lastLines}
+            \`\`\`
+            </details>
+            `;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });


### PR DESCRIPTION
## 개요

GitHub Actions workflow를 수정하여 unit test 결과를 PR 코멘트로 자동 추가합니다.

## 변경 사항

### `.github/workflows/unit-tests.yml`
- pytest 출력을 `test-output.txt` 파일로 저장
- `continue-on-error: true`로 테스트 실패 시에도 workflow 계속 실행
- `actions/github-script@v7`을 사용하여 테스트 결과를 PR 코멘트로 작성
  - 테스트 요약 줄 표시 (예: `45 passed in 2.3s`)
  - 접을 수 있는 섹션에 마지막 15줄 출력 포함

## PR 코멘트 예시

```
🧪 Unit Test Results

45 passed in 2.3s

📋 Test Output (last 15 lines) ▼
[마지막 15줄의 테스트 출력]
```

## 장점
- 별도의 파일이나 artifact 업로드 없이 간단하게 결과 확인
- 테스트 요약과 상세 정보를 한 번에 확인 가능
- 추가 의존성 필요 없음
- 매 PR 업데이트마다 자동으로 테스트 결과 코멘트 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>