### PR TITLE
[refactor] IPO 모듈 리팩토링 - fetch_ipo_schedule을 ipo/ 폴더로 분리

### DIFF
--- a/docs/done/6_ipo_implementation.md
+++ b/docs/done/6_ipo_implementation.md
@@ -1,0 +1,223 @@
+# IPO 모듈 리팩토링 구현 가이드
+
+## 1. 개요
+
+`korea_investment_stock.py`의 `fetch_ipo_schedule()` 메서드를 `ipo/` 폴더로 분리하여 모듈화한다.
+
+**접근 방식**: 단순 함수 추출 + 위임 패턴
+
+---
+
+## 2. 파일 구조
+
+### 변경 전
+```
+ipo/
+├── __init__.py           # 헬퍼 함수 export
+└── ipo_helpers.py        # 유틸리티 함수 7개
+```
+
+### 변경 후
+```
+ipo/
+├── __init__.py           # 전체 export (수정)
+├── ipo_helpers.py        # 유틸리티 함수 (기존 유지)
+└── ipo_api.py            # API 호출 함수 (신규)
+```
+
+---
+
+## 3. 구현 상세
+
+### 3.1 신규 파일: `ipo/ipo_api.py`
+
+```python
+"""
+IPO API 모듈
+
+공모주 청약 일정 조회 API를 제공합니다.
+"""
+import logging
+from datetime import datetime, timedelta
+
+import requests
+
+from .ipo_helpers import validate_date_format, validate_date_range
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_ipo_schedule(
+    base_url: str,
+    access_token: str,
+    api_key: str,
+    api_secret: str,
+    from_date: str = None,
+    to_date: str = None,
+    symbol: str = ""
+) -> dict:
+    """공모주 청약 일정 조회
+
+    Args:
+        base_url: API base URL
+        access_token: Bearer 토큰
+        api_key: API key
+        api_secret: API secret
+        from_date: 조회 시작일 (YYYYMMDD, 기본값: 오늘)
+        to_date: 조회 종료일 (YYYYMMDD, 기본값: 30일 후)
+        symbol: 종목코드 (선택, 공백시 전체 조회)
+
+    Returns:
+        dict: 공모주 청약 일정 정보
+
+    Raises:
+        ValueError: 날짜 형식 오류시
+    """
+    # 날짜 기본값 설정
+    if not from_date:
+        from_date = datetime.now().strftime("%Y%m%d")
+    if not to_date:
+        to_date = (datetime.now() + timedelta(days=30)).strftime("%Y%m%d")
+
+    # 날짜 유효성 검증
+    if not validate_date_format(from_date) or not validate_date_format(to_date):
+        raise ValueError("날짜 형식은 YYYYMMDD 이어야 합니다.")
+
+    if not validate_date_range(from_date, to_date):
+        raise ValueError("시작일은 종료일보다 이전이어야 합니다.")
+
+    path = "uapi/domestic-stock/v1/ksdinfo/pub-offer"
+    url = f"{base_url}/{path}"
+    headers = {
+        "content-type": "application/json",
+        "authorization": access_token,
+        "appKey": api_key,
+        "appSecret": api_secret,
+        "tr_id": "HHKDB669108C0",
+        "custtype": "P"
+    }
+
+    params = {
+        "SHT_CD": symbol,
+        "CTS": "",
+        "F_DT": from_date,
+        "T_DT": to_date
+    }
+
+    resp = requests.get(url, headers=headers, params=params)
+    resp_json = resp.json()
+
+    if resp_json.get('rt_cd') != '0':
+        logger.error(f"공모주 조회 실패: {resp_json.get('msg1', 'Unknown error')}")
+
+    return resp_json
+```
+
+### 3.2 수정 파일: `ipo/__init__.py`
+
+```python
+"""
+IPO 모듈
+
+공모주 관련 API 및 유틸리티 함수를 제공합니다.
+"""
+from .ipo_helpers import (
+    validate_date_format,
+    validate_date_range,
+    parse_ipo_date_range,
+    format_ipo_date,
+    calculate_ipo_d_day,
+    get_ipo_status,
+    format_number,
+)
+from .ipo_api import fetch_ipo_schedule
+
+__all__ = [
+    # API
+    "fetch_ipo_schedule",
+    # Helpers
+    "validate_date_format",
+    "validate_date_range",
+    "parse_ipo_date_range",
+    "format_ipo_date",
+    "calculate_ipo_d_day",
+    "get_ipo_status",
+    "format_number",
+]
+```
+
+### 3.3 수정 파일: `korea_investment_stock.py`
+
+**Import 변경** (26-34줄):
+```python
+# 변경 전
+from .ipo import (
+    validate_date_format,
+    validate_date_range,
+    parse_ipo_date_range,
+    format_ipo_date,
+    calculate_ipo_d_day,
+    get_ipo_status,
+    format_number,
+)
+
+# 변경 후
+from .ipo import fetch_ipo_schedule as _fetch_ipo_schedule
+```
+
+**메서드 변경** (752-848줄 → 약 15줄):
+```python
+def fetch_ipo_schedule(
+    self,
+    from_date: str = None,
+    to_date: str = None,
+    symbol: str = ""
+) -> dict:
+    """공모주 청약 일정 조회
+
+    예탁원정보(공모주청약일정) API를 통해 공모주 정보를 조회합니다.
+
+    Args:
+        from_date: 조회 시작일 (YYYYMMDD, 기본값: 오늘)
+        to_date: 조회 종료일 (YYYYMMDD, 기본값: 30일 후)
+        symbol: 종목코드 (선택, 공백시 전체 조회)
+
+    Returns:
+        dict: 공모주 청약 일정 정보
+    """
+    return _fetch_ipo_schedule(
+        self.base_url,
+        self.access_token,
+        self.api_key,
+        self.api_secret,
+        from_date,
+        to_date,
+        symbol
+    )
+```
+
+---
+
+## 4. 영향받는 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `ipo/ipo_api.py` | 신규 | API 호출 로직 (~80줄) |
+| `ipo/__init__.py` | 수정 | fetch_ipo_schedule export 추가 |
+| `korea_investment_stock.py` | 수정 | import 변경 + 위임 호출 (~79줄 삭제) |
+
+**변경 불필요**:
+- `cache/cached_korea_investment.py` - broker 위임 유지
+- `korea_investment_stock/__init__.py` - IPO 헬퍼 export 유지
+
+---
+
+## 5. 테스트
+
+```bash
+# 단위 테스트
+pytest -m "not integration"
+
+# IPO 통합 테스트 (API 자격 증명 필요)
+pytest korea_investment_stock/tests/test_ipo_integration.py -v
+```

--- a/docs/done/6_ipo_prd.md
+++ b/docs/done/6_ipo_prd.md
@@ -1,0 +1,136 @@
+# IPO 모듈 리팩토링 PRD
+
+## 1. 개요
+
+### 1.1 목표
+`korea_investment_stock.py`에 있는 IPO 관련 코드를 `ipo/` 폴더로 분리하여 모듈화한다.
+
+### 1.2 배경
+현재 IPO 관련 코드가 두 곳에 분산되어 있음:
+- **korea_investment_stock.py**: `fetch_ipo_schedule()` 메서드 (API 호출 로직)
+- **ipo/ipo_helpers.py**: 유틸리티 함수들 (날짜 검증, 파싱 등)
+
+기존 패키지 구조(cache, token_storage, rate_limit)와 일관성을 위해 IPO 관련 코드를 `ipo/` 폴더에 통합한다.
+
+---
+
+## 2. 현재 코드 분석
+
+### 2.1 korea_investment_stock.py 내 IPO 코드
+
+**위치**: 752-848줄
+
+- 날짜 기본값 설정 (오늘 ~ 30일 후)
+- 날짜 유효성 검증 (validate_date_format, validate_date_range 호출)
+- API 호출: `/uapi/domestic-stock/v1/ksdinfo/pub-offer`
+- TR ID: `HHKDB669108C0`
+
+### 2.2 ipo/ 폴더 현재 구조
+
+```
+ipo/
+├── __init__.py           # 헬퍼 함수 export
+└── ipo_helpers.py        # 유틸리티 함수 7개
+```
+
+**ipo_helpers.py 함수 목록**:
+| 함수 | 설명 |
+|------|------|
+| `validate_date_format()` | YYYYMMDD 형식 검증 |
+| `validate_date_range()` | 시작일 <= 종료일 검증 |
+| `parse_ipo_date_range()` | "2024.01.15~2024.01.16" 파싱 |
+| `format_ipo_date()` | YYYYMMDD → YYYY-MM-DD 변환 |
+| `calculate_ipo_d_day()` | 청약일까지 남은 일수 계산 |
+| `get_ipo_status()` | "예정"/"진행중"/"마감" 상태 판단 |
+| `format_number()` | 천단위 콤마 추가 |
+
+### 2.3 IPO 관련 외부 참조
+
+- **패키지 __init__.py**: IPO 헬퍼 함수 export
+- **cache/cached_korea_investment.py**: `fetch_ipo_schedule()` 캐싱 지원 (broker 위임)
+
+---
+
+## 3. 리팩토링 방안
+
+### 3.1 Option A: 단순 이동 (권장)
+
+`fetch_ipo_schedule` 로직을 별도 모듈로 분리하되, `KoreaInvestment` 클래스에서 위임 호출.
+
+**새 구조**:
+```
+ipo/
+├── __init__.py           # 전체 export
+├── ipo_helpers.py        # 유틸리티 함수 (기존 유지)
+└── ipo_api.py            # IPO API 호출 함수 (신규)
+```
+
+**장점**:
+- 기존 API 호환성 유지 (`broker.fetch_ipo_schedule()` 그대로 사용)
+- IPO 로직 응집도 향상
+- 단위 테스트 용이
+
+### 3.2 Option B: Wrapper 패턴 (Cache/RateLimit 스타일)
+
+`IpoKoreaInvestment` 래퍼 클래스 생성.
+
+**평가**: Not Recommended (오버엔지니어링 - IPO 기능 하나를 위해 과도함)
+
+---
+
+## 4. 영향도 분석
+
+### 4.1 Breaking Changes
+**없음** - 기존 API 완전 호환
+- `broker.fetch_ipo_schedule()` 그대로 사용 가능
+- 헬퍼 함수 import 경로 동일
+
+### 4.2 영향받는 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| korea_investment_stock.py | 수정 | import 변경, 메서드 간소화 |
+| ipo/__init__.py | 수정 | fetch_ipo_schedule export 추가 |
+| ipo/ipo_api.py | 신규 | API 호출 로직 |
+| cache/cached_korea_investment.py | 없음 | 변경 불필요 (broker 위임 유지) |
+
+### 4.3 코드 라인 수 변화
+
+| 파일 | 현재 | 변경 후 | 차이 |
+|------|------|---------|------|
+| korea_investment_stock.py | 849줄 | ~770줄 | -79줄 |
+| ipo/ipo_api.py | 0줄 | ~80줄 | +80줄 |
+
+---
+
+## 5. 테스트 계획
+
+```bash
+# 단위 테스트
+pytest -m "not integration"
+
+# IPO 통합 테스트 (API 자격 증명 필요)
+pytest korea_investment_stock/tests/test_ipo_integration.py -v
+```
+
+---
+
+## 6. 마이그레이션 가이드
+
+**사용자 영향**: 없음
+
+```python
+# 기존 코드 그대로 동작
+broker = KoreaInvestment(...)
+ipos = broker.fetch_ipo_schedule()
+
+# 헬퍼 함수도 그대로 동작
+from korea_investment_stock import get_ipo_status, format_ipo_date
+```
+
+---
+
+## 7. 관련 문서
+
+- [6_ipo_implementation.md](6_ipo_implementation.md) - 구현 상세
+- [6_ipo_todo.md](6_ipo_todo.md) - 구현 체크리스트

--- a/docs/done/6_ipo_todo.md
+++ b/docs/done/6_ipo_todo.md
@@ -1,0 +1,34 @@
+# IPO 모듈 리팩토링 TODO
+
+## Phase 1: 코드 이동
+
+- [x] `ipo/ipo_api.py` 파일 생성
+  - [x] import 문 작성 (logging, datetime, requests)
+  - [x] `fetch_ipo_schedule()` 함수 구현
+  - [x] docstring 작성
+
+- [x] `ipo/__init__.py` 업데이트
+  - [x] `from .ipo_api import fetch_ipo_schedule` 추가
+  - [x] `__all__`에 `fetch_ipo_schedule` 추가
+
+- [x] `korea_investment_stock.py` 수정
+  - [x] import 변경: `from .ipo import fetch_ipo_schedule as _fetch_ipo_schedule`
+  - [x] 기존 `fetch_ipo_schedule` 메서드 삭제 (752-848줄)
+  - [x] 새 `fetch_ipo_schedule` 위임 메서드 작성
+
+## Phase 2: 테스트
+
+- [x] 단위 테스트 통과 확인
+  ```bash
+  pytest -m "not integration"
+  ```
+
+- [ ] IPO 통합 테스트 통과 확인 (선택)
+  ```bash
+  pytest korea_investment_stock/tests/test_ipo_integration.py -v
+  ```
+
+## Phase 3: 정리
+
+- [ ] CLAUDE.md 문서 업데이트 (필요시)
+- [x] docs/start/6_ipo_prd.md → docs/done/ 이동

--- a/korea_investment_stock/ipo/__init__.py
+++ b/korea_investment_stock/ipo/__init__.py
@@ -1,7 +1,7 @@
 """
-IPO 헬퍼 모듈
+IPO 모듈
 
-공모주 관련 유틸리티 함수를 제공합니다.
+공모주 관련 API 및 유틸리티 함수를 제공합니다.
 """
 from .ipo_helpers import (
     validate_date_format,
@@ -12,8 +12,12 @@ from .ipo_helpers import (
     get_ipo_status,
     format_number,
 )
+from .ipo_api import fetch_ipo_schedule
 
 __all__ = [
+    # API
+    "fetch_ipo_schedule",
+    # Helpers
     "validate_date_format",
     "validate_date_range",
     "parse_ipo_date_range",

--- a/korea_investment_stock/ipo/ipo_api.py
+++ b/korea_investment_stock/ipo/ipo_api.py
@@ -1,0 +1,109 @@
+"""
+IPO API 모듈
+
+공모주 청약 일정 조회 API를 제공합니다.
+"""
+import logging
+from datetime import datetime, timedelta
+
+import requests
+
+from .ipo_helpers import validate_date_format, validate_date_range
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_ipo_schedule(
+    base_url: str,
+    access_token: str,
+    api_key: str,
+    api_secret: str,
+    from_date: str = None,
+    to_date: str = None,
+    symbol: str = ""
+) -> dict:
+    """공모주 청약 일정 조회
+
+    예탁원정보(공모주청약일정) API를 통해 공모주 정보를 조회합니다.
+    한국투자 HTS(eFriend Plus) > [0667] 공모주청약 화면과 동일한 기능입니다.
+
+    Args:
+        base_url: API base URL
+        access_token: Bearer 토큰
+        api_key: API key
+        api_secret: API secret
+        from_date: 조회 시작일 (YYYYMMDD, 기본값: 오늘)
+        to_date: 조회 종료일 (YYYYMMDD, 기본값: 30일 후)
+        symbol: 종목코드 (선택, 공백시 전체 조회)
+
+    Returns:
+        dict: 공모주 청약 일정 정보
+            {
+                "rt_cd": "0",  # 성공여부
+                "msg_cd": "응답코드",
+                "msg1": "응답메시지",
+                "output1": [
+                    {
+                        "record_date": "기준일",
+                        "sht_cd": "종목코드",
+                        "isin_name": "종목명",
+                        "fix_subscr_pri": "공모가",
+                        "face_value": "액면가",
+                        "subscr_dt": "청약기간",  # "2024.01.15~2024.01.16"
+                        "pay_dt": "납입일",
+                        "refund_dt": "환불일",
+                        "list_dt": "상장/등록일",
+                        "lead_mgr": "주간사",
+                        "pub_bf_cap": "공모전자본금",
+                        "pub_af_cap": "공모후자본금",
+                        "assign_stk_qty": "당사배정물량"
+                    }
+                ]
+            }
+
+    Raises:
+        ValueError: 날짜 형식 오류시
+
+    Note:
+        - 예탁원에서 제공한 자료이므로 정보용으로만 사용하시기 바랍니다.
+        - 실제 청약시에는 반드시 공식 공모주 청약 공고문을 확인하세요.
+    """
+    # 날짜 기본값 설정
+    if not from_date:
+        from_date = datetime.now().strftime("%Y%m%d")
+    if not to_date:
+        to_date = (datetime.now() + timedelta(days=30)).strftime("%Y%m%d")
+
+    # 날짜 유효성 검증
+    if not validate_date_format(from_date) or not validate_date_format(to_date):
+        raise ValueError("날짜 형식은 YYYYMMDD 이어야 합니다.")
+
+    if not validate_date_range(from_date, to_date):
+        raise ValueError("시작일은 종료일보다 이전이어야 합니다.")
+
+    path = "uapi/domestic-stock/v1/ksdinfo/pub-offer"
+    url = f"{base_url}/{path}"
+    headers = {
+        "content-type": "application/json",
+        "authorization": access_token,
+        "appKey": api_key,
+        "appSecret": api_secret,
+        "tr_id": "HHKDB669108C0",
+        "custtype": "P"  # 개인
+    }
+
+    params = {
+        "SHT_CD": symbol,
+        "CTS": "",
+        "F_DT": from_date,
+        "T_DT": to_date
+    }
+
+    resp = requests.get(url, headers=headers, params=params)
+    resp_json = resp.json()
+
+    # 에러 처리
+    if resp_json.get('rt_cd') != '0':
+        logger.error(f"공모주 조회 실패: {resp_json.get('msg1', 'Unknown error')}")
+
+    return resp_json


### PR DESCRIPTION
## Summary

- `korea_investment_stock.py`에 있는 IPO 관련 코드를 `ipo/` 폴더로 분리하여 모듈화
- 기존 패키지 구조(cache, token_storage, rate_limit)와 일관성 확보
- 위임 패턴을 사용하여 기존 API 완전 호환 유지

## 변경 사항

### 새 구조
```
ipo/
├── __init__.py           # 전체 export (수정)
├── ipo_helpers.py        # 유틸리티 함수 (기존 유지)
└── ipo_api.py            # API 호출 함수 (신규)
```

### 코드 라인 수 변화
| 파일 | 변경 |
|------|------|
| korea_investment_stock.py | ~79줄 감소 (위임 패턴으로 간소화) |
| ipo/ipo_api.py | ~100줄 추가 (API 로직 이동) |

## Breaking Changes

**없음** - 기존 API 완전 호환
- `broker.fetch_ipo_schedule()` 그대로 사용 가능
- 헬퍼 함수 import 경로 동일

## Test Plan

- [x] `pytest -m "not integration"` - 단위 테스트 통과
- [x] IPO 모듈 import 테스트 통과
- [x] 헬퍼 함수 호환성 확인

## Related Issues

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)