### PR TITLE
[fix] Unit test Redis 연결 오류 수정

### DIFF
--- a/korea_investment_stock/cache/test_cached_integration.py
+++ b/korea_investment_stock/cache/test_cached_integration.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 import time
-from korea_investment_stock import KoreaInvestment, CachedKoreaInvestment
+from korea_investment_stock import KoreaInvestment, CachedKoreaInvestment, Config
 
 
 @pytest.fixture
@@ -14,7 +14,13 @@ def broker():
     if not all([api_key, api_secret, acc_no]):
         pytest.skip("API credentials not set")
 
-    return KoreaInvestment(api_key, api_secret, acc_no)
+    config = Config(
+        api_key=api_key,
+        api_secret=api_secret,
+        acc_no=acc_no,
+        token_storage_type="file",
+    )
+    return KoreaInvestment(config=config)
 
 
 class TestCachedKoreaInvestment:

--- a/korea_investment_stock/test_integration_us_stocks.py
+++ b/korea_investment_stock/test_integration_us_stocks.py
@@ -5,23 +5,25 @@ TODO-33 Phase 2.2
 import unittest
 from unittest.mock import Mock, patch
 
-from korea_investment_stock import KoreaInvestment
+from korea_investment_stock import KoreaInvestment, Config
 
 
 class TestUSStockIntegration(unittest.TestCase):
     """미국 주식 통합 테스트"""
-    
+
     def setUp(self):
         """Mock broker 인스턴스 설정"""
-        # access token 발급을 건너뛰고 직접 설정
-        self.patcher = patch('korea_investment_stock.korea_investment_stock.KoreaInvestment.issue_access_token')
+        # TokenManager의 토큰 발급을 건너뛰고 직접 설정
+        self.patcher = patch('korea_investment_stock.token.manager.TokenManager._issue_token')
         self.patcher.start()
-        
-        self.broker = KoreaInvestment(
+
+        config = Config(
             api_key="test_key",
             api_secret="test_secret",
-            acc_no="12345678-01"
+            acc_no="12345678-01",
+            token_storage_type="file",
         )
+        self.broker = KoreaInvestment(config=config)
         self.broker.access_token = "Bearer test_token"
     
     def tearDown(self):
@@ -334,16 +336,18 @@ class TestCachedKoreaInvestmentWrapper(unittest.TestCase):
 
     def setUp(self):
         """Mock broker 설정"""
-        self.patcher = patch('korea_investment_stock.korea_investment_stock.KoreaInvestment.issue_access_token')
+        self.patcher = patch('korea_investment_stock.token.manager.TokenManager._issue_token')
         self.patcher.start()
 
         from korea_investment_stock import CachedKoreaInvestment
 
-        self.broker = KoreaInvestment(
+        config = Config(
             api_key="test_key",
             api_secret="test_secret",
-            acc_no="12345678-01"
+            acc_no="12345678-01",
+            token_storage_type="file",
         )
+        self.broker = KoreaInvestment(config=config)
         self.broker.access_token = "Bearer test_token"
         self.cached_broker = CachedKoreaInvestment(self.broker, price_ttl=5)
 
@@ -385,16 +389,18 @@ class TestRateLimitedKoreaInvestmentWrapper(unittest.TestCase):
 
     def setUp(self):
         """Mock broker 설정"""
-        self.patcher = patch('korea_investment_stock.korea_investment_stock.KoreaInvestment.issue_access_token')
+        self.patcher = patch('korea_investment_stock.token.manager.TokenManager._issue_token')
         self.patcher.start()
 
         from korea_investment_stock import RateLimitedKoreaInvestment
 
-        self.broker = KoreaInvestment(
+        config = Config(
             api_key="test_key",
             api_secret="test_secret",
-            acc_no="12345678-01"
+            acc_no="12345678-01",
+            token_storage_type="file",
         )
+        self.broker = KoreaInvestment(config=config)
         self.broker.access_token = "Bearer test_token"
         self.rate_limited_broker = RateLimitedKoreaInvestment(self.broker, calls_per_second=15)
 

--- a/korea_investment_stock/test_korea_investment_stock.py
+++ b/korea_investment_stock/test_korea_investment_stock.py
@@ -1,7 +1,7 @@
 import os
 from unittest import TestCase, skip
 
-from korea_investment_stock import KoreaInvestment, API_RETURN_CODE
+from korea_investment_stock import KoreaInvestment, API_RETURN_CODE, Config
 
 
 class TestKoreaInvestment(TestCase):
@@ -11,11 +11,13 @@ class TestKoreaInvestment(TestCase):
         api_secret = os.getenv('KOREA_INVESTMENT_API_SECRET')
         acc_no = os.getenv('KOREA_INVESTMENT_ACCOUNT_NO')
 
-        cls.kis = KoreaInvestment(
+        config = Config(
             api_key=api_key,
             api_secret=api_secret,
             acc_no=acc_no,
+            token_storage_type="file",
         )
+        cls.kis = KoreaInvestment(config=config)
 
     def test_stock_info(self):
         stock_market_list = [


### PR DESCRIPTION
## Summary
- 환경 변수에 `KOREA_INVESTMENT_REDIS_PASSWORD`가 설정되어 있을 때 unit test가 Redis 연결을 시도하여 실패하는 문제 수정
- `KoreaInvestment` 생성 시 `Config` 객체를 사용하여 `token_storage_type="file"` 명시
- `test_integration_us_stocks.py`의 mock 패치 경로를 `TokenManager._issue_token`으로 수정

## Changes
- `test_korea_investment_stock.py`: Config 객체 사용
- `test_cached_integration.py`: Config 객체 사용
- `test_rate_limited_integration.py`: broker fixture로 리팩토링, Config 객체 사용
- `test_integration_us_stocks.py`: Config 객체 사용 및 mock 패치 경로 수정

## Test Results
```
================ 197 passed, 4 skipped, 11 deselected in 25.22s ================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)