### PR TITLE
[fix] 해외 마스터 파일 파서 대소문자 처리 수정

### DIFF
--- a/korea_investment_stock/parsers/overseas_master_parser.py
+++ b/korea_investment_stock/parsers/overseas_master_parser.py
@@ -59,7 +59,20 @@ def parse_overseas_stock_master(base_dir: str, market_code: str) -> pd.DataFrame
     Returns:
         pd.DataFrame: 종목 정보가 담긴 DataFrame
     """
-    file_path = f"{base_dir}/{market_code}mst.cod"
+    from pathlib import Path
+
+    base_path = Path(base_dir)
+    file_name = f"{market_code}mst.cod"
+
+    # 대소문자 구분 없이 파일 찾기 (Linux는 대소문자 구분, ZIP 내부는 대문자)
+    file_path = None
+    for f in base_path.iterdir():
+        if f.name.lower() == file_name.lower():
+            file_path = f
+            break
+
+    if file_path is None:
+        raise FileNotFoundError(f"마스터 파일을 찾을 수 없습니다: {file_name}")
 
     df = pd.read_table(
         file_path,


### PR DESCRIPTION
## Summary
- Linux(GitHub Actions)에서 파일 대소문자 구분으로 인한 테스트 실패 수정
- ZIP 내부 파일명(`NASMST.COD`)과 파서가 찾는 파일명(`nasmst.cod`) 불일치 해결

## Problem
| 환경 | 파일 시스템 | 테스트 결과 |
|------|-----------|-----------|
| macOS/Windows | 대소문자 구분 안함 | ✅ Pass |
| Linux (CI) | 대소문자 구분 | ❌ Fail |

## Solution
대소문자 구분 없이 파일을 찾도록 파서 로직 수정:
```python
for f in base_path.iterdir():
    if f.name.lower() == file_name.lower():
        file_path = f
        break
```

## Test Results
```
korea_investment_stock/tests/test_overseas_symbols_integration.py ... 4 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)