### PR TITLE
fix: 해외 마스터 파일 파서 테스트 mock 수정

### DIFF
--- a/korea_investment_stock/parsers/test_overseas_master_parser.py
+++ b/korea_investment_stock/parsers/test_overseas_master_parser.py
@@ -2,7 +2,8 @@
 해외 마스터 파일 파서 단위 테스트
 """
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
+from pathlib import Path
 import pandas as pd
 
 from .overseas_master_parser import (
@@ -64,9 +65,19 @@ class TestParseOverseasStockMaster:
     """파서 함수 테스트"""
 
     @patch("pandas.read_table")
-    def test_parse_overseas_stock_master_calls_read_table(self, mock_read_table):
+    @patch("pathlib.Path.iterdir")
+    def test_parse_overseas_stock_master_calls_read_table(
+        self, mock_iterdir, mock_read_table
+    ):
         """pd.read_table 호출 확인"""
-        mock_df = pd.DataFrame({"심볼": ["AAPL", "MSFT"], "한글명": ["애플", "마이크로소프트"]})
+        # Mock file path found via iterdir
+        mock_file = MagicMock(spec=Path)
+        mock_file.name = "nasmst.cod"
+        mock_iterdir.return_value = [mock_file]
+
+        mock_df = pd.DataFrame(
+            {"심볼": ["AAPL", "MSFT"], "한글명": ["애플", "마이크로소프트"]}
+        )
         mock_read_table.return_value = mock_df
 
         result = parse_overseas_stock_master("/tmp", "nas")
@@ -75,19 +86,35 @@ class TestParseOverseasStockMaster:
         assert len(result) == 2
 
     @patch("pandas.read_table")
-    def test_parse_overseas_stock_master_correct_file_path(self, mock_read_table):
+    @patch("pathlib.Path.iterdir")
+    def test_parse_overseas_stock_master_correct_file_path(
+        self, mock_iterdir, mock_read_table
+    ):
         """올바른 파일 경로 생성 확인"""
+        # Mock file path found via iterdir
+        mock_file = MagicMock(spec=Path)
+        mock_file.name = "hksmst.cod"
+        mock_iterdir.return_value = [mock_file]
+
         mock_df = pd.DataFrame()
         mock_read_table.return_value = mock_df
 
         parse_overseas_stock_master("/data", "hks")
 
         call_args = mock_read_table.call_args
-        assert call_args[0][0] == "/data/hksmst.cod"
+        # 파일 경로는 iterdir에서 찾은 mock_file이 전달됨
+        assert call_args[0][0] == mock_file
 
     @patch("pandas.read_table")
-    def test_parse_overseas_stock_master_correct_encoding(self, mock_read_table):
+    @patch("pathlib.Path.iterdir")
+    def test_parse_overseas_stock_master_correct_encoding(
+        self, mock_iterdir, mock_read_table
+    ):
         """CP949 인코딩 사용 확인"""
+        mock_file = MagicMock(spec=Path)
+        mock_file.name = "nasmst.cod"
+        mock_iterdir.return_value = [mock_file]
+
         mock_df = pd.DataFrame()
         mock_read_table.return_value = mock_df
 
@@ -97,8 +124,15 @@ class TestParseOverseasStockMaster:
         assert call_args[1]["encoding"] == "cp949"
 
     @patch("pandas.read_table")
-    def test_parse_overseas_stock_master_tab_separator(self, mock_read_table):
+    @patch("pathlib.Path.iterdir")
+    def test_parse_overseas_stock_master_tab_separator(
+        self, mock_iterdir, mock_read_table
+    ):
         """탭 구분자 사용 확인"""
+        mock_file = MagicMock(spec=Path)
+        mock_file.name = "nasmst.cod"
+        mock_iterdir.return_value = [mock_file]
+
         mock_df = pd.DataFrame()
         mock_read_table.return_value = mock_df
 
@@ -108,8 +142,15 @@ class TestParseOverseasStockMaster:
         assert call_args[1]["sep"] == "\t"
 
     @patch("pandas.read_table")
-    def test_parse_overseas_stock_master_string_dtype(self, mock_read_table):
+    @patch("pathlib.Path.iterdir")
+    def test_parse_overseas_stock_master_string_dtype(
+        self, mock_iterdir, mock_read_table
+    ):
         """문자열 타입 지정 확인"""
+        mock_file = MagicMock(spec=Path)
+        mock_file.name = "nasmst.cod"
+        mock_iterdir.return_value = [mock_file]
+
         mock_df = pd.DataFrame()
         mock_read_table.return_value = mock_df
 


### PR DESCRIPTION
## Summary
- `parse_overseas_stock_master` 함수가 `Path.iterdir()`를 사용하여 대소문자 구분 없이 파일 검색하도록 변경됨
- 테스트에서 `pd.read_table`만 mock하여 `FileNotFoundError` 발생
- `pathlib.Path.iterdir`도 함께 mock하여 테스트 수정

## Test plan
- [x] `pytest korea_investment_stock/parsers/test_overseas_master_parser.py -v` - 11 passed
- [x] `pytest -m "not integration"` - 197 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)