### PR TITLE
[chore] 공통 Unit Test Workflow 적용

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,198 +6,21 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  unit-tests:
-    name: Unit Tests (Python 3.12)
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: 'pip'
-          cache-dependency-path: 'pyproject.toml'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
-
-      - name: Run unit tests with coverage
-        id: pytest
-        run: |
-          pytest korea_investment_stock/ -v \
-            -m "not integration" \
-            --ignore=korea_investment_stock/test_korea_investment_stock.py \
-            --ignore=korea_investment_stock/test_integration_us_stocks.py \
-            --ignore=korea_investment_stock/cache/test_cached_integration.py \
-            -k "not (Redis or redis_storage or TestTokenStorageIntegration)" \
-            --cov=korea_investment_stock \
-            --cov-report=xml \
-            --cov-report=term-missing \
-            --junitxml=junit-unit.xml \
-            2>&1 | tee test-output.txt
-        continue-on-error: true
-
-      - name: Upload unit test results
-        uses: actions/upload-artifact@v4
-        with:
-          name: unit-test-results
-          path: |
-            junit-unit.xml
-            coverage.xml
-            test-output.txt
-
-  integration-tests:
-    name: Integration Tests (Python 3.12 + Docker)
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: 'pip'
-          cache-dependency-path: 'pyproject.toml'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev,redis]"
-
-      - name: Run integration tests
-        id: integration-pytest
-        run: |
-          pytest -m integration -v \
-            --junitxml=junit-integration.xml \
-            2>&1 | tee integration-test-output.txt
-        continue-on-error: true
-
-      - name: Upload integration test results
-        uses: actions/upload-artifact@v4
-        with:
-          name: integration-test-results
-          path: |
-            junit-integration.xml
-            integration-test-output.txt
-
-  report:
-    name: Test Report
-    needs: [unit-tests, integration-tests]
-    runs-on: ubuntu-latest
-    if: always()
-
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-
-      - name: Generate combined report
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-
-            // Parse unit test results
-            let unitOutput = '';
-            let unitStats = { passed: 0, failed: 0, skipped: 0, total: 0, time: '0s' };
-            try {
-              unitOutput = fs.readFileSync('unit-test-results/test-output.txt', 'utf8');
-              const match = unitOutput.match(/(\d+) passed(?:, (\d+) failed)?(?:, (\d+) skipped)?.*in ([\d.]+)s/);
-              if (match) {
-                unitStats.passed = parseInt(match[1]) || 0;
-                unitStats.failed = parseInt(match[2]) || 0;
-                unitStats.skipped = parseInt(match[3]) || 0;
-                unitStats.total = unitStats.passed + unitStats.failed + unitStats.skipped;
-                unitStats.time = match[4] + 's';
-              }
-            } catch (e) {
-              console.log('Unit test results not found');
-            }
-
-            // Parse integration test results
-            let integrationOutput = '';
-            let integrationStats = { passed: 0, failed: 0, skipped: 0, total: 0, time: '0s' };
-            try {
-              integrationOutput = fs.readFileSync('integration-test-results/integration-test-output.txt', 'utf8');
-              const match = integrationOutput.match(/(\d+) passed(?:, (\d+) failed)?(?:, (\d+) skipped)?.*in ([\d.]+)s/);
-              if (match) {
-                integrationStats.passed = parseInt(match[1]) || 0;
-                integrationStats.failed = parseInt(match[2]) || 0;
-                integrationStats.skipped = parseInt(match[3]) || 0;
-                integrationStats.total = integrationStats.passed + integrationStats.failed + integrationStats.skipped;
-                integrationStats.time = match[4] + 's';
-              }
-            } catch (e) {
-              console.log('Integration test results not found');
-            }
-
-            // Parse coverage
-            let coverage = 'N/A';
-            try {
-              const covOutput = fs.readFileSync('unit-test-results/test-output.txt', 'utf8');
-              const covMatch = covOutput.match(/TOTAL\s+\d+\s+\d+\s+(\d+)%/);
-              if (covMatch) {
-                coverage = covMatch[1] + '%';
-              }
-            } catch (e) {}
-
-            // Determine overall status
-            const totalFailed = unitStats.failed + integrationStats.failed;
-            const statusMessage = totalFailed === 0
-              ? '### ✅ All Tests Passed!'
-              : `### ❌ ${totalFailed} Test(s) Failed`;
-
-            // Build status icons
-            const unitStatus = unitStats.failed === 0 ? '✅' : '❌';
-            const unitDetail = `${unitStats.passed} passed` +
-              (unitStats.failed > 0 ? `, ${unitStats.failed} failed` : '') +
-              (unitStats.skipped > 0 ? `, ${unitStats.skipped} skipped` : '');
-
-            const integrationStatus = integrationStats.failed === 0 ? '✅' : '❌';
-            const integrationDetail = `${integrationStats.passed} passed` +
-              (integrationStats.failed > 0 ? `, ${integrationStats.failed} failed` : '') +
-              (integrationStats.skipped > 0 ? `, ${integrationStats.skipped} skipped` : '');
-
-            // Generate comment
-            const comment = `## 🧪 Test Results Summary
-
-            | 구분 | 상태 | 결과 | 시간 |
-            |------|:----:|------|------|
-            | **Unit Tests** | ${unitStatus} | ${unitDetail} | ${unitStats.time} |
-            | **Integration Tests** | ${integrationStatus} | ${integrationDetail} | ${integrationStats.time} |
-            | **Coverage** | 📊 | **${coverage}** | - |
-
-            ${statusMessage}
-
-            <details>
-            <summary>📋 Unit Test Details</summary>
-
-            \`\`\`
-            ${unitOutput.split('\n').slice(-30).join('\n')}
-            \`\`\`
-
-            </details>
-
-            <details>
-            <summary>🐳 Integration Test Details</summary>
-
-            \`\`\`
-            ${integrationOutput.split('\n').slice(-20).join('\n')}
-            \`\`\`
-
-            </details>
-            `;
-
-            // Post comment
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: comment
-            });
+  test:
+    uses: kenshin579/actions/.github/workflows/unit-test-python.yml@main
+    with:
+      python_version: '3.12'
+      test_path: 'korea_investment_stock/'
+      run_unit_tests: true
+      run_integration_tests: true
+      unit_test_args: >-
+        -m "not integration"
+        --ignore=korea_investment_stock/test_korea_investment_stock.py
+        --ignore=korea_investment_stock/test_integration_us_stocks.py
+        --ignore=korea_investment_stock/cache/test_cached_integration.py
+        -k "not (Redis or redis_storage or TestTokenStorageIntegration)"
+      integration_test_args: '-m integration'
+      coverage_enabled: true
+      coverage_package: 'korea_investment_stock'
+      install_extras: 'dev,redis'
+      post_comment: true


### PR DESCRIPTION
## Summary

- actions 저장소의 재사용 가능한 `unit-test-python.yml` workflow 호출로 변경
- 기존 195줄 → 18줄로 간소화
- Unit/Integration 테스트 및 Coverage 수집 유지

## Test plan

- [ ] PR에서 Unit Tests 실행 확인
- [ ] PR에서 Integration Tests 실행 확인
- [ ] PR 코멘트에 테스트 결과 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)