### PR TITLE
[fix] release workflow에 통합 테스트 ignore 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
           --ignore=korea_investment_stock/test_korea_investment_stock.py \
           --ignore=korea_investment_stock/test_integration_us_stocks.py \
           --ignore=korea_investment_stock/cache/test_cached_integration.py \
+          --ignore=korea_investment_stock/tests/test_integration_investor.py \
           -k "not (Redis or redis_storage or TestTokenStorageIntegration)"
       tag_name: ${{ needs.release.outputs.new_version }}
     secrets:


### PR DESCRIPTION
## Summary

- `test_integration_investor.py` 파일을 release workflow test에서 제외
- 해당 파일은 API 자격 증명이 필요한 통합 테스트로, CI 환경에서 실행 시 실패 발생

## 문제 상황

v0.14.0 release 시 pypi job의 test step에서 실패:
```
ERROR test_integration_investor.py::TestInvestorTradingIntegration::test_samsung_investor_trading
ValueError: API credentials required. Missing: api_key, api_secret, acc_no
```

## 해결

`release.yml`의 test_command에 `--ignore=korea_investment_stock/tests/test_integration_investor.py` 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)