### PR TITLE
feat: Add fetch_investor_trend_by_market() API method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@
 
 ### Added
 
+#### 시장별 투자자매매동향(시세) API 추가 (#120)
+
+시장별 투자자 유형(외국인, 개인, 기관 등)의 매매 현황을 시간대별로 조회합니다.
+한국투자 HTS [0403] 시장별 시간동향 화면과 동일한 기능입니다.
+
+```python
+from korea_investment_stock import KoreaInvestment
+
+broker = KoreaInvestment()
+
+# 코스피 종합 투자자 매매동향
+result = broker.fetch_investor_trend_by_market("KSP", "0001")
+
+# 코스닥 종합 투자자 매매동향
+result = broker.fetch_investor_trend_by_market("KSQ", "1001")
+
+# ETF 전체 투자자 매매동향
+result = broker.fetch_investor_trend_by_market("ETF", "T000")
+
+if result['rt_cd'] == '0':
+    for item in result['output']:
+        print(f"외국인 순매수: {item['frgn_ntby_qty']}주")
+        print(f"기관 순매수: {item['orgn_ntby_qty']}주")
+        print(f"개인 순매수: {item['prsn_ntby_qty']}주")
+```
+
+**주요 기능**:
+- 시장별(코스피, 코스닥, ETF 등) 투자자 매매동향 조회
+- 투자자 유형별(외국인, 개인, 기관, 증권, 투신, 사모펀드, 은행, 보험, 기금 등) 순매수 수량/금액 조회
+- 자동 토큰 재발급 지원
+
+**시장 코드 상수 추가**:
+- `MARKET_INVESTOR_TREND_CODE`: 시장 코드 (KSP, KSQ, ETF 등)
+- `SECTOR_CODE`: 업종 코드 (0001, 1001, T000 등)
+
 #### 종목별 투자자매매동향(일별) API 추가 (#114)
 
 특정 종목의 날짜별 외국인/기관/개인 매수매도 현황을 조회합니다.

--- a/korea_investment_stock/__init__.py
+++ b/korea_investment_stock/__init__.py
@@ -24,6 +24,9 @@ from .constants import (
     # 상품유형 코드
     PRDT_TYPE_CD,
     PRDT_TYPE_CD_BY_COUNTRY,  # 국가별 상품유형코드 매핑
+    # 시장별 투자자동향 코드
+    MARKET_INVESTOR_TREND_CODE,  # 시장 코드 (KSP, KSQ, ETF 등)
+    SECTOR_CODE,                  # 업종 코드 (0001, 1001, T000 등)
     # 기타
     API_RETURN_CODE,
 )
@@ -88,6 +91,9 @@ __all__ = [
     # 상수 정의 - 상품유형 코드
     "PRDT_TYPE_CD",
     "PRDT_TYPE_CD_BY_COUNTRY",
+    # 상수 정의 - 시장별 투자자동향 코드
+    "MARKET_INVESTOR_TREND_CODE",
+    "SECTOR_CODE",
     # 상수 정의 - 기타
     "API_RETURN_CODE",
 

--- a/korea_investment_stock/constants.py
+++ b/korea_investment_stock/constants.py
@@ -165,3 +165,36 @@ API_RETURN_CODE = {
     "NO_DATA": "7",  # 조회할 자료가 없습니다
     "RATE_LIMIT_EXCEEDED": "EGW00201",  # Rate limit 초과
 }
+
+# =============================================================================
+# 시장별 투자자동향 - 시장 코드 (MARKET_INVESTOR_TREND_CODE)
+# =============================================================================
+
+MARKET_INVESTOR_TREND_CODE = {
+    "KOSPI": "KSP",         # 코스피
+    "KOSDAQ": "KSQ",        # 코스닥
+    "ETF": "ETF",           # ETF
+    "ELW": "ELW",           # ELW
+    "ETN": "ETN",           # ETN
+    "FUTURES": "K2I",       # 선물/콜옵션/풋옵션
+    "STOCK_FUTURES": "999", # 주식선물
+    "MINI": "MKI",          # 미니
+    "WEEKLY_MONTH": "WKM",  # 위클리(월)
+    "WEEKLY_THUR": "WKI",   # 위클리(목)
+    "KOSDAQ150": "KQI",     # 코스닥150
+}
+
+# =============================================================================
+# 시장별 투자자동향 - 업종 코드 (SECTOR_CODE)
+# =============================================================================
+
+SECTOR_CODE = {
+    "KOSPI_TOTAL": "0001",   # 코스피 종합
+    "KOSDAQ_TOTAL": "1001",  # 코스닥 종합
+    "FUTURES": "F001",       # 선물
+    "CALL_OPTION": "OC01",   # 콜옵션
+    "PUT_OPTION": "OP01",    # 풋옵션
+    "ETF_TOTAL": "T000",     # ETF 전체
+    "ELW_TOTAL": "W000",     # ELW 전체
+    "ETN_TOTAL": "E199",     # ETN 전체
+}

--- a/korea_investment_stock/korea_investment_stock.py
+++ b/korea_investment_stock/korea_investment_stock.py
@@ -952,3 +952,102 @@ class KoreaInvestment:
             "FID_ETC_CLS_CODE": ""
         }
         return self._request_with_token_refresh("GET", url, headers, params)
+
+    def fetch_investor_trend_by_market(
+        self,
+        market_code: str = "KSP",
+        sector_code: str = "0001"
+    ) -> dict:
+        """시장별 투자자매매동향(시세) 조회 [v1_국내주식-074]
+
+        시장별 투자자 유형(외국인, 개인, 기관 등)의 매매 현황을 시간대별로 조회합니다.
+        한국투자 HTS [0403] 시장별 시간동향 화면과 동일한 기능입니다.
+
+        API 정보:
+            - 경로: /uapi/domestic-stock/v1/quotations/inquire-investor-time-by-market
+            - Method: GET
+            - 실전 TR ID: FHPTJ04030000
+            - 모의투자: 미지원
+
+        Args:
+            market_code (str): 시장구분 코드 (기본값: "KSP")
+                - "KSP": 코스피
+                - "KSQ": 코스닥
+                - "ETF": ETF
+                - "ELW": ELW
+                - "ETN": ETN
+                - "K2I": 선물/콜옵션/풋옵션
+                - "999": 주식선물
+                - "MKI": 미니
+                - "WKM": 위클리(월)
+                - "WKI": 위클리(목)
+                - "KQI": 코스닥150
+            sector_code (str): 업종구분 코드 (기본값: "0001")
+                - "0001": 코스피 종합
+                - "1001": 코스닥 종합
+                - "F001": 선물
+                - "OC01": 콜옵션
+                - "OP01": 풋옵션
+                - "T000": ETF 전체
+                - "W000": ELW 전체
+                - "E199": ETN 전체
+
+        Returns:
+            dict: API 응답 딕셔너리
+                - rt_cd: 성공 실패 여부 ("0": 성공)
+                - msg_cd: 응답코드
+                - msg1: 응답메시지
+                - output: 시간대별 투자자 매매동향 리스트
+
+        투자자 유형별 응답 필드:
+            - frgn_*: 외국인
+            - prsn_*: 개인
+            - orgn_*: 기관계
+            - scrt_*: 증권
+            - ivtr_*: 투자신탁
+            - pe_fund_*: 사모펀드
+            - bank_*: 은행
+            - insu_*: 보험
+            - mrbn_*: 종금
+            - fund_*: 기금
+            - etc_orgt_*: 기타단체
+            - etc_corp_*: 기타법인
+
+        세부 필드 접미사:
+            - _seln_vol: 매도 거래량
+            - _shnu_vol: 매수 거래량
+            - _ntby_qty: 순매수 수량
+            - _seln_tr_pbmn: 매도 거래 대금
+            - _shnu_tr_pbmn: 매수 거래 대금
+            - _ntby_tr_pbmn: 순매수 거래 대금
+
+        Example:
+            >>> # 코스피 종합 투자자 매매동향
+            >>> result = broker.fetch_investor_trend_by_market("KSP", "0001")
+            >>> if result['rt_cd'] == '0':
+            ...     for item in result['output']:
+            ...         print(f"시간: {item.get('bsop_hour_clss_code', 'N/A')}")
+            ...         print(f"외국인 순매수: {item['frgn_ntby_qty']}주")
+            ...         print(f"기관 순매수: {item['orgn_ntby_qty']}주")
+            ...         print(f"개인 순매수: {item['prsn_ntby_qty']}주")
+
+            >>> # 코스닥 종합 투자자 매매동향
+            >>> result = broker.fetch_investor_trend_by_market("KSQ", "1001")
+
+            >>> # ETF 전체 투자자 매매동향
+            >>> result = broker.fetch_investor_trend_by_market("ETF", "T000")
+        """
+        path = "uapi/domestic-stock/v1/quotations/inquire-investor-time-by-market"
+        url = f"{self.base_url}/{path}"
+        headers = {
+            "content-type": "application/json",
+            "authorization": self.access_token,
+            "appKey": self.api_key,
+            "appSecret": self.api_secret,
+            "tr_id": "FHPTJ04030000"
+        }
+        params = {
+            "fid_input_iscd": market_code,
+            "fid_input_iscd_2": sector_code
+        }
+        return self._request_with_token_refresh("GET", url, headers, params)

--- a/korea_investment_stock/tests/test_investor_trend_by_market.py
+++ b/korea_investment_stock/tests/test_investor_trend_by_market.py
@@ -1,0 +1,76 @@
+"""시장별 투자자매매동향(시세) 통합 테스트
+
+이 테스트는 실제 API 자격 증명이 필요합니다.
+환경 변수 설정:
+    - KOREA_INVESTMENT_API_KEY
+    - KOREA_INVESTMENT_API_SECRET
+    - KOREA_INVESTMENT_ACCOUNT_NO
+
+실행:
+    pytest korea_investment_stock/tests/test_investor_trend_by_market.py -v
+"""
+import pytest
+
+
+@pytest.mark.integration
+class TestInvestorTrendByMarketIntegration:
+    """시장별 투자자매매동향(시세) API 통합 테스트"""
+
+    @pytest.fixture
+    def broker(self):
+        """실제 API 자격 증명으로 broker 생성"""
+        from korea_investment_stock import KoreaInvestment
+        return KoreaInvestment()
+
+    def test_kospi_investor_trend(self, broker):
+        """코스피 종합 투자자 동향 조회"""
+        result = broker.fetch_investor_trend_by_market("KSP", "0001")
+
+        assert result['rt_cd'] == '0', f"API Error: {result.get('msg1', 'Unknown error')}"
+        assert 'output' in result
+
+    def test_kosdaq_investor_trend(self, broker):
+        """코스닥 종합 투자자 동향 조회"""
+        result = broker.fetch_investor_trend_by_market("KSQ", "1001")
+
+        assert result['rt_cd'] == '0', f"API Error: {result.get('msg1', 'Unknown error')}"
+        assert 'output' in result
+
+    def test_etf_investor_trend(self, broker):
+        """ETF 전체 투자자 동향 조회"""
+        result = broker.fetch_investor_trend_by_market("ETF", "T000")
+
+        assert result['rt_cd'] == '0', f"API Error: {result.get('msg1', 'Unknown error')}"
+        assert 'output' in result
+
+    def test_default_parameters(self, broker):
+        """기본 파라미터(코스피 종합) 테스트"""
+        result = broker.fetch_investor_trend_by_market()
+
+        assert result['rt_cd'] == '0', f"API Error: {result.get('msg1', 'Unknown error')}"
+        assert 'output' in result
+
+    def test_investor_trend_response_fields(self, broker):
+        """응답 필드 검증"""
+        result = broker.fetch_investor_trend_by_market("KSP", "0001")
+
+        if result['rt_cd'] == '0' and result.get('output'):
+            item = result['output'][0]
+
+            # 주요 투자자 유형별 순매수 필드 존재 확인
+            expected_fields = [
+                'frgn_ntby_qty',   # 외국인 순매수 수량
+                'prsn_ntby_qty',   # 개인 순매수 수량
+                'orgn_ntby_qty',   # 기관 순매수 수량
+            ]
+
+            for field in expected_fields:
+                assert field in item, f"Missing field: {field}"
+
+    def test_context_manager(self, broker):
+        """컨텍스트 매니저 테스트"""
+        from korea_investment_stock import KoreaInvestment
+
+        with KoreaInvestment() as ctx_broker:
+            result = ctx_broker.fetch_investor_trend_by_market("KSP", "0001")
+            assert result['rt_cd'] == '0'


### PR DESCRIPTION
## Summary

시장별 투자자매매동향(시세) API를 추가합니다. (#120)

- `fetch_investor_trend_by_market(market_code, sector_code)` 메서드 추가
- `MARKET_INVESTOR_TREND_CODE` 상수 추가 (KSP, KSQ, ETF 등)
- `SECTOR_CODE` 상수 추가 (0001, 1001, T000 등)
- 통합 테스트 코드 추가
- CHANGELOG.md 업데이트

## API 정보

| 항목 | 값 |
|------|-----|
| API명 | 시장별 투자자매매동향(시세) |
| API ID | v1_국내주식-074 |
| API 경로 | `/uapi/domestic-stock/v1/quotations/inquire-investor-time-by-market` |
| TR ID | FHPTJ04030000 |
| HTS 화면 | [0403] 시장별 시간동향 |

## 사용 예시

```python
from korea_investment_stock import KoreaInvestment

broker = KoreaInvestment()

# 코스피 종합 투자자 매매동향
result = broker.fetch_investor_trend_by_market("KSP", "0001")

# 코스닥 종합 투자자 매매동향
result = broker.fetch_investor_trend_by_market("KSQ", "1001")

# ETF 전체 투자자 매매동향
result = broker.fetch_investor_trend_by_market("ETF", "T000")
```

## Test plan

- [ ] 단위 테스트 실행: `pytest -m "not integration"`
- [ ] 통합 테스트 실행: `pytest korea_investment_stock/tests/test_investor_trend_by_market.py -v`
- [ ] Import 확인: `from korea_investment_stock import MARKET_INVESTOR_TREND_CODE, SECTOR_CODE`

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)