### PR TITLE
fix: Skip integration tests when API credentials unavailable

### DIFF
--- a/korea_investment_stock/tests/test_investor_trend_by_market.py
+++ b/korea_investment_stock/tests/test_investor_trend_by_market.py
@@ -9,10 +9,24 @@
 실행:
     pytest korea_investment_stock/tests/test_investor_trend_by_market.py -v
 """
+import os
 import pytest
 
 
+def _has_api_credentials() -> bool:
+    """API 자격 증명이 설정되어 있는지 확인"""
+    return all([
+        os.environ.get("KOREA_INVESTMENT_API_KEY"),
+        os.environ.get("KOREA_INVESTMENT_API_SECRET"),
+        os.environ.get("KOREA_INVESTMENT_ACCOUNT_NO"),
+    ])
+
+
 @pytest.mark.integration
+@pytest.mark.skipif(
+    not _has_api_credentials(),
+    reason="API credentials not available (KOREA_INVESTMENT_* env vars required)"
+)
 class TestInvestorTrendByMarketIntegration:
     """시장별 투자자매매동향(시세) API 통합 테스트"""
 


### PR DESCRIPTION
Add pytest.mark.skipif decorator to skip tests in CI environment
where KOREA_INVESTMENT_* environment variables are not set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
