### PR TITLE
docs: Add investor trend API documentation

### DIFF
--- a/docs/start/3_investor_api.md
+++ b/docs/start/3_investor_api.md
@@ -1,0 +1,268 @@
+# 투자자별 매매현황 조회 API
+
+개인, 외국인, 기관 등 투자자별 매매현황을 조회할 수 있는 API 목록입니다.
+
+## API 목록
+
+| API명 | API 경로 | TR ID | 설명 |
+|-------|----------|-------|------|
+| **주식현재가 투자자** | `/uapi/domestic-stock/v1/quotations/inquire-investor` | FHKST01010900 | 종목별 개인/외국인/기관 일자별 순매수 수량·금액 조회 |
+| **국내기관_외국인 매매종목가집계** | `/uapi/domestic-stock/v1/quotations/foreign-institution-total` | FHPTJ04400000 | 장중 외국인/기관 매매종목 순매수 상위 조회 (가집계) |
+| **시장별 투자자매매동향(시세)** | `/uapi/domestic-stock/v1/quotations/inquire-investor-time-by-market` | FHPTJ04030000 | 코스피/코스닥 등 시장별 투자자 실시간 매매 현황 |
+| **시장별 투자자매매동향(일별)** | `/uapi/domestic-stock/v1/quotations/inquire-investor-daily-by-market` | FHPTJ04040000 | 시장별 투자자 일별 매매 동향 |
+| **종목별 투자자매매동향(일별)** | `/uapi/domestic-stock/v1/quotations/investor-trade-by-stock-daily` | FHPTJ04160001 | 특정 종목의 투자자별 일별 매매 내역 |
+| **종목별 외인기관 추정가집계** | `/uapi/domestic-stock/v1/quotations/investor-trend-estimate` | HHPTJ04160200 | 장중 종목별 외국인/기관 추정 순매수 |
+| **외국계 매매종목 가집계** | `/uapi/domestic-stock/v1/quotations/frgnmem-trade-estimate` | FHKST644100C0 | 외국계 증권사 매매종목 가집계 |
+| **종목별 외국계 순매수추이** | `/uapi/domestic-stock/v1/quotations/frgnmem-pchs-trend` | FHKST644400C0 | 특정 종목의 외국계 시간별 순매수 추이 |
+
+---
+
+## 상세 설명
+
+### 1. 주식현재가 투자자 [v1_국내주식-012]
+
+- **API 경로**: `/uapi/domestic-stock/v1/quotations/inquire-investor`
+- **TR ID**: FHKST01010900
+- **HTS 화면**: -
+
+#### 개요
+주식현재가 투자자 API입니다. 개인, 외국인, 기관 등 투자 정보를 확인할 수 있습니다.
+
+#### 주요 파라미터
+| 파라미터 | 설명 |
+|----------|------|
+| FID_COND_MRKT_DIV_CODE | J: KRX, NX: NXT, UN: 통합 |
+| FID_INPUT_ISCD | 종목코드 (ex: 005930) |
+
+#### 응답 데이터
+- `prsn_ntby_qty`: 개인 순매수 수량
+- `frgn_ntby_qty`: 외국인 순매수 수량
+- `orgn_ntby_qty`: 기관계 순매수 수량
+- `prsn_ntby_tr_pbmn`: 개인 순매수 거래 대금
+- `frgn_ntby_tr_pbmn`: 외국인 순매수 거래 대금
+- `orgn_ntby_tr_pbmn`: 기관계 순매수 거래 대금
+
+#### 유의사항
+- 외국인은 외국인(외국인투자등록 고유번호가 있는 경우) + 기타 외국인을 지칭
+- 당일 데이터는 장 종료 후 제공
+
+---
+
+### 2. 국내기관_외국인 매매종목가집계 [국내주식-037]
+
+- **API 경로**: `/uapi/domestic-stock/v1/quotations/foreign-institution-total`
+- **TR ID**: FHPTJ04400000
+- **HTS 화면**: [0440] 외국인/기관 매매종목 가집계
+
+#### 개요
+장중 외국인/기관 매매종목 가집계 정보를 조회합니다.
+
+#### 주요 파라미터
+| 파라미터 | 설명 |
+|----------|------|
+| FID_INPUT_ISCD | 0000: 전체, 0001: 코스피, 1001: 코스닥 |
+| FID_DIV_CLS_CODE | 0: 수량정렬, 1: 금액정렬 |
+| FID_RANK_SORT_CLS_CODE | 0: 순매수상위, 1: 순매도상위 |
+| FID_ETC_CLS_CODE | 0: 전체, 1: 외국인, 2: 기관계, 3: 기타 |
+
+#### 응답 데이터
+- `frgn_ntby_qty`: 외국인 순매수 수량
+- `orgn_ntby_qty`: 기관계 순매수 수량
+- `ivtr_ntby_qty`: 투자신탁 순매수 수량
+- `bank_ntby_qty`: 은행 순매수 수량
+- `insu_ntby_qty`: 보험 순매수 수량
+- `fund_ntby_qty`: 기금 순매수 수량
+
+#### 유의사항
+- 증권사 직원이 장중에 집계/입력한 자료의 단순 누계
+- 입력시간: 외국인 09:30, 11:20, 13:20, 14:30 / 기관종합 10:00, 11:20, 13:20, 14:30
+- 입력 시간은 ±10분 차이 발생 가능
+
+---
+
+### 3. 시장별 투자자매매동향(시세) [v1_국내주식-074]
+
+- **API 경로**: `/uapi/domestic-stock/v1/quotations/inquire-investor-time-by-market`
+- **TR ID**: FHPTJ04030000
+- **HTS 화면**: [0403] 시장별 시간동향
+
+#### 개요
+시장별 투자자 실시간 매매동향을 조회합니다.
+
+#### 주요 파라미터
+| 파라미터 | 설명 |
+|----------|------|
+| fid_input_iscd | 시장구분 - KSP: 코스피, KSQ: 코스닥, ETF, ELW, ETN 등 |
+| fid_input_iscd_2 | 업종구분 - 0001: 코스피 종합, 1001: 코스닥 종합 등 |
+
+#### 응답 데이터
+투자자별 매도/매수/순매수 거래량 및 거래대금:
+- 외국인 (`frgn_*`)
+- 개인 (`prsn_*`)
+- 기관계 (`orgn_*`)
+- 증권 (`scrt_*`)
+- 투자신탁 (`ivtr_*`)
+- 사모펀드 (`pe_fund_*`)
+- 은행 (`bank_*`)
+- 보험 (`insu_*`)
+- 종금 (`mrbn_*`)
+- 기금 (`fund_*`)
+- 기타단체 (`etc_orgt_*`)
+- 기타법인 (`etc_corp_*`)
+
+---
+
+### 4. 시장별 투자자매매동향(일별) [국내주식-075]
+
+- **API 경로**: `/uapi/domestic-stock/v1/quotations/inquire-investor-daily-by-market`
+- **TR ID**: FHPTJ04040000
+- **HTS 화면**: [0404] 시장별 일별동향
+
+#### 개요
+시장별 투자자 일별 매매동향을 조회합니다.
+
+#### 주요 파라미터
+| 파라미터 | 설명 |
+|----------|------|
+| FID_COND_MRKT_DIV_CODE | 시장구분코드 (업종 U) |
+| FID_INPUT_ISCD | 업종분류코드 |
+| FID_INPUT_DATE_1 | 조회 시작일 (ex: 20240517) |
+| FID_INPUT_ISCD_1 | KSP: 코스피, KSQ: 코스닥 |
+
+#### 응답 데이터
+- 업종 지수 정보 (현재가, 전일대비 등)
+- 투자자별 순매수 수량/금액 (외국인, 개인, 기관 등)
+- 외국인 등록/비등록 구분 데이터 포함
+
+---
+
+### 5. 종목별 투자자매매동향(일별)
+
+- **API 경로**: `/uapi/domestic-stock/v1/quotations/investor-trade-by-stock-daily`
+- **TR ID**: FHPTJ04160001
+- **HTS 화면**: [0416] 종목별 일별동향
+
+#### 개요
+특정 종목의 투자자별 일별 매매 내역을 조회합니다.
+
+#### 주요 파라미터
+| 파라미터 | 설명 |
+|----------|------|
+| FID_COND_MRKT_DIV_CODE | J: KRX, NX: NXT, UN: 통합 |
+| FID_INPUT_ISCD | 종목코드 (6자리) |
+| FID_INPUT_DATE_1 | 조회일 (ex: 20250812) |
+
+#### 응답 데이터
+- 주가 정보 (종가, 시가, 고가, 저가)
+- 투자자별 순매수 수량/금액
+- 투자자별 매도/매수 거래량/대금
+- 외국인 등록/비등록 구분 데이터
+
+#### 유의사항
+- 단위: 금액(백만원), 수량(주)
+- 해당일 조회는 장 종료 후 정상 조회 가능
+
+---
+
+### 6. 종목별 외인기관 추정가집계 [v1_국내주식-046]
+
+- **API 경로**: `/uapi/domestic-stock/v1/quotations/investor-trend-estimate`
+- **TR ID**: HHPTJ04160200
+- **MTS 화면**: 국내 현재가 > 투자자 > 투자자동향 > 추정(주)
+
+#### 개요
+장중 종목별 외국인/기관 추정 순매수를 조회합니다.
+
+#### 주요 파라미터
+| 파라미터 | 설명 |
+|----------|------|
+| MKSC_SHRN_ISCD | 종목코드 |
+
+#### 응답 데이터
+| 필드 | 설명 |
+|------|------|
+| bsop_hour_gb | 입력구분 (1: 09:30, 2: 10:00, 3: 11:20, 4: 13:20, 5: 14:30) |
+| frgn_fake_ntby_qty | 외국인 수량 (가집계) |
+| orgn_fake_ntby_qty | 기관 수량 (가집계) |
+| sum_fake_ntby_qty | 합산 수량 (가집계) |
+
+#### 유의사항
+- 증권사 직원이 장중에 집계/입력한 자료의 단순 누계
+- 사정에 따라 입력 시간 변동 가능
+
+---
+
+### 7. 외국계 매매종목 가집계 [국내주식-161]
+
+- **API 경로**: `/uapi/domestic-stock/v1/quotations/frgnmem-trade-estimate`
+- **TR ID**: FHKST644100C0
+- **HTS 화면**: [0430] 외국계 매매종목 가집계
+
+#### 개요
+외국계 증권사의 매매종목 가집계를 조회합니다.
+
+#### 주요 파라미터
+| 파라미터 | 설명 |
+|----------|------|
+| FID_INPUT_ISCD | 0000: 전체, 1001: 코스피, 2001: 코스닥 |
+| FID_RANK_SORT_CLS_CODE | 0: 금액순, 1: 수량순 |
+| FID_RANK_SORT_CLS_CODE_2 | 0: 매수순, 1: 매도순 |
+
+#### 응답 데이터
+- `glob_ntsl_qty`: 외국계 순매도 수량
+- `glob_total_seln_qty`: 외국계 총매도 수량
+- `glob_total_shnu_qty`: 외국계 총매수 수량
+
+---
+
+### 8. 종목별 외국계 순매수추이 [국내주식-164]
+
+- **API 경로**: `/uapi/domestic-stock/v1/quotations/frgnmem-pchs-trend`
+- **TR ID**: FHKST644400C0
+- **HTS 화면**: [0433] 종목별 외국계 순매수추이
+
+#### 개요
+특정 종목의 외국계 시간별 순매수 추이를 조회합니다.
+
+#### 주요 파라미터
+| 파라미터 | 설명 |
+|----------|------|
+| FID_INPUT_ISCD | 종목코드 (ex: 005930) |
+| FID_INPUT_ISCD_2 | 외국계 전체 (99999) |
+| FID_COND_MRKT_DIV_CODE | J (KRX만 지원) |
+
+#### 응답 데이터
+- `bsop_hour`: 영업시간
+- `frgn_seln_vol`: 외국인 매도 거래량
+- `frgn_shnu_vol`: 외국인 매수 거래량
+- `glob_ntby_qty`: 외국계 순매수 수량
+- `frgn_ntby_qty_icdc`: 외국인 순매수 수량 증감
+
+---
+
+## 용도별 API 추천
+
+### 종목별 조회
+
+| 용도 | 추천 API |
+|------|----------|
+| 일별 투자자 동향 | 주식현재가 투자자, 종목별 투자자매매동향(일별) |
+| 장중 외인/기관 추정 | 종목별 외인기관 추정가집계 |
+| 외국계 시간별 추이 | 종목별 외국계 순매수추이 |
+
+### 시장 전체 조회
+
+| 용도 | 추천 API |
+|------|----------|
+| 실시간 동향 | 시장별 투자자매매동향(시세) |
+| 일별 동향 | 시장별 투자자매매동향(일별) |
+| 외인/기관 순매수 상위 | 국내기관_외국인 매매종목가집계, 외국계 매매종목 가집계 |
+
+---
+
+## 공통 유의사항
+
+1. **가집계 데이터**: 증권사 직원이 장중 입력한 데이터로 확정 수치가 아닙니다.
+2. **당일 확정 데이터**: 장 종료 후 제공됩니다.
+3. **모의투자**: 대부분의 투자자 동향 API는 모의투자를 지원하지 않습니다.
+4. **외국인 구분**: 외국인 = 외국인(등록) + 기타 외국인(비등록)

--- a/docs/start/4_investor_time_implementation.md
+++ b/docs/start/4_investor_time_implementation.md
@@ -1,0 +1,330 @@
+# 시장별 투자자매매동향(시세) API 구현
+
+## 개요
+
+| 항목 | 값 |
+|------|-----|
+| API명 | 시장별 투자자매매동향(시세) |
+| API ID | v1_국내주식-074 |
+| API 경로 | `/uapi/domestic-stock/v1/quotations/inquire-investor-time-by-market` |
+| TR ID | FHPTJ04030000 |
+| 모의투자 | 미지원 |
+
+---
+
+## Phase 1: korea_investment_stock 라이브러리
+
+### 1.1 API 메서드 추가
+
+**파일**: `korea_investment_stock/korea_investment_stock.py`
+
+```python
+def fetch_investor_trend_by_market(
+    self,
+    market_code: str = "KSP",
+    sector_code: str = "0001"
+) -> dict:
+    """
+    시장별 투자자매매동향(시세) API
+
+    Args:
+        market_code: 시장구분 (KSP=코스피, KSQ=코스닥, ETF, ELW, ETN 등)
+        sector_code: 업종구분 (0001=코스피종합, 1001=코스닥종합 등)
+
+    Returns:
+        dict: API 응답 (투자자별 매매 현황)
+    """
+    path = "uapi/domestic-stock/v1/quotations/inquire-investor-time-by-market"
+    url = f"{self.base_url}/{path}"
+
+    headers = {
+        "content-type": "application/json",
+        "authorization": self.access_token,
+        "appKey": self.api_key,
+        "appSecret": self.api_secret,
+        "tr_id": "FHPTJ04030000"
+    }
+
+    params = {
+        "fid_input_iscd": market_code,
+        "fid_input_iscd_2": sector_code
+    }
+
+    return self._request_with_token_refresh("GET", url, headers, params)
+```
+
+### 1.2 상수 추가
+
+**파일**: `korea_investment_stock/constants.py`
+
+```python
+# 시장별 투자자동향 - 시장 코드
+MARKET_INVESTOR_TREND_CODE = {
+    "KOSPI": "KSP",
+    "KOSDAQ": "KSQ",
+    "ETF": "ETF",
+    "ELW": "ELW",
+    "ETN": "ETN",
+    "FUTURES": "K2I",
+    "STOCK_FUTURES": "999",
+    "MINI": "MKI",
+    "WEEKLY_MONTH": "WKM",
+    "WEEKLY_THUR": "WKI",
+    "KOSDAQ150": "KQI"
+}
+
+# 시장별 투자자동향 - 업종 코드 (주요 항목만)
+SECTOR_CODE = {
+    "KOSPI_TOTAL": "0001",
+    "KOSDAQ_TOTAL": "1001",
+    "FUTURES": "F001",
+    "CALL_OPTION": "OC01",
+    "PUT_OPTION": "OP01",
+    "ETF_TOTAL": "T000",
+    "ELW_TOTAL": "W000",
+    "ETN_TOTAL": "E199"
+}
+```
+
+### 1.3 테스트 코드
+
+**파일**: `tests/test_investor_trend.py`
+
+```python
+import pytest
+from korea_investment_stock import KoreaInvestment
+
+class TestInvestorTrendByMarket:
+
+    @pytest.fixture
+    def client(self):
+        return KoreaInvestment()
+
+    def test_fetch_kospi_investor_trend(self, client):
+        """코스피 종합 투자자 동향 조회"""
+        result = client.fetch_investor_trend_by_market("KSP", "0001")
+
+        assert result['rt_cd'] == '0'
+        assert 'output' in result
+
+    def test_fetch_kosdaq_investor_trend(self, client):
+        """코스닥 종합 투자자 동향 조회"""
+        result = client.fetch_investor_trend_by_market("KSQ", "1001")
+
+        assert result['rt_cd'] == '0'
+```
+
+### 1.4 버전 업데이트
+
+`pyproject.toml` 버전을 `0.16.0`으로 업데이트
+
+---
+
+## Phase 2: DB 스키마 (moneyflow.advenoh.pe.kr)
+
+DB 스키마는 `moneyflow.advenoh.pe.kr` 레포지토리에서 Liquibase로 관리합니다.
+
+### 2.1 Liquibase Changelog
+
+**파일**: `moneyflow.advenoh.pe.kr/backend/db/changelog/2025-12/8_create_market_investor_trend.sql`
+
+```sql
+--liquibase formatted sql
+--changeset kenshin579:create_market_investor_trend
+-- comment: 시장별 투자자 매매동향(시세) 테이블 생성
+
+CREATE TABLE IF NOT EXISTS market_investor_trend (
+    id INT AUTO_INCREMENT PRIMARY KEY COMMENT 'PK',
+
+    -- 시장 정보
+    market_code VARCHAR(10) NOT NULL COMMENT '시장코드 (KSP=코스피, KSQ=코스닥 등)',
+    sector_code VARCHAR(10) NOT NULL COMMENT '업종코드 (0001=코스피종합, 1001=코스닥종합 등)',
+    collected_at DATETIME NOT NULL COMMENT '수집일시',
+    trade_date DATE NOT NULL COMMENT '거래일',
+
+    -- 외국인
+    foreign_net_qty BIGINT NULL COMMENT '외국인 순매수량',
+    foreign_net_amount BIGINT NULL COMMENT '외국인 순매수금액',
+
+    -- 개인
+    individual_net_qty BIGINT NULL COMMENT '개인 순매수량',
+    individual_net_amount BIGINT NULL COMMENT '개인 순매수금액',
+
+    -- 기관
+    institution_net_qty BIGINT NULL COMMENT '기관 순매수량',
+    institution_net_amount BIGINT NULL COMMENT '기관 순매수금액',
+
+    -- 증권
+    securities_net_qty BIGINT NULL COMMENT '증권 순매수량',
+    securities_net_amount BIGINT NULL COMMENT '증권 순매수금액',
+
+    -- 투자신탁
+    investment_trust_net_qty BIGINT NULL COMMENT '투자신탁 순매수량',
+    investment_trust_net_amount BIGINT NULL COMMENT '투자신탁 순매수금액',
+
+    -- 사모펀드
+    pe_fund_net_qty BIGINT NULL COMMENT '사모펀드 순매수량',
+    pe_fund_net_amount BIGINT NULL COMMENT '사모펀드 순매수금액',
+
+    -- 은행
+    bank_net_qty BIGINT NULL COMMENT '은행 순매수량',
+    bank_net_amount BIGINT NULL COMMENT '은행 순매수금액',
+
+    -- 보험
+    insurance_net_qty BIGINT NULL COMMENT '보험 순매수량',
+    insurance_net_amount BIGINT NULL COMMENT '보험 순매수금액',
+
+    -- 기금
+    pension_fund_net_qty BIGINT NULL COMMENT '기금 순매수량',
+    pension_fund_net_amount BIGINT NULL COMMENT '기금 순매수금액',
+
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT '생성일',
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일',
+
+    UNIQUE KEY uk_market_sector_date (market_code, sector_code, trade_date),
+    INDEX idx_trade_date (trade_date)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='시장별 투자자 매매동향';
+
+--rollback DROP TABLE IF EXISTS market_investor_trend;
+```
+
+### 2.2 마이그레이션 실행
+
+```bash
+cd moneyflow.advenoh.pe.kr/backend/db
+./liquibase.sh update
+```
+
+---
+
+## Phase 3: stock-data-batch
+
+### 3.1 DB 모델 추가
+
+**파일**: `database/models.py`
+
+```python
+class MarketInvestorTrend(BaseModel):
+    """시장별 투자자 매매동향 (시세)"""
+
+    id = AutoField()
+    market_code = CharField(max_length=10)
+    sector_code = CharField(max_length=10)
+    collected_at = DateTimeField()
+    trade_date = DateField()
+
+    # 외국인/개인/기관 (순매수량, 순매수금액)
+    foreign_net_qty = BigIntegerField(null=True)
+    foreign_net_amount = BigIntegerField(null=True)
+    individual_net_qty = BigIntegerField(null=True)
+    individual_net_amount = BigIntegerField(null=True)
+    institution_net_qty = BigIntegerField(null=True)
+    institution_net_amount = BigIntegerField(null=True)
+
+    # 기타 투자자 (순매수량, 순매수금액만)
+    securities_net_qty = BigIntegerField(null=True)
+    securities_net_amount = BigIntegerField(null=True)
+    investment_trust_net_qty = BigIntegerField(null=True)
+    investment_trust_net_amount = BigIntegerField(null=True)
+    pe_fund_net_qty = BigIntegerField(null=True)
+    pe_fund_net_amount = BigIntegerField(null=True)
+    bank_net_qty = BigIntegerField(null=True)
+    bank_net_amount = BigIntegerField(null=True)
+    insurance_net_qty = BigIntegerField(null=True)
+    insurance_net_amount = BigIntegerField(null=True)
+    pension_fund_net_qty = BigIntegerField(null=True)
+    pension_fund_net_amount = BigIntegerField(null=True)
+
+    created_at = DateTimeField(default=datetime.now)
+    updated_at = DateTimeField(default=datetime.now)
+
+    class Meta:
+        table_name = 'market_investor_trend'
+        indexes = (
+            (('market_code', 'sector_code', 'trade_date'), True),
+        )
+```
+
+### 3.2 API 응답 매핑
+
+**파일**: `services/stock_collector.py`
+
+```python
+def _map_market_investor_trend(market_code: str, sector_code: str, data: Dict) -> Dict:
+    """API 응답 -> DB 모델 매핑"""
+    return {
+        'market_code': market_code,
+        'sector_code': sector_code,
+        'collected_at': datetime.now(),
+        'trade_date': date.today(),
+
+        'foreign_net_qty': safe_int(data.get('frgn_ntby_qty')),
+        'foreign_net_amount': safe_int(data.get('frgn_ntby_tr_pbmn')),
+        'individual_net_qty': safe_int(data.get('prsn_ntby_qty')),
+        'individual_net_amount': safe_int(data.get('prsn_ntby_tr_pbmn')),
+        'institution_net_qty': safe_int(data.get('orgn_ntby_qty')),
+        'institution_net_amount': safe_int(data.get('orgn_ntby_tr_pbmn')),
+
+        'securities_net_qty': safe_int(data.get('scrt_ntby_qty')),
+        'securities_net_amount': safe_int(data.get('scrt_ntby_tr_pbmn')),
+        'investment_trust_net_qty': safe_int(data.get('ivtr_ntby_qty')),
+        'investment_trust_net_amount': safe_int(data.get('ivtr_ntby_tr_pbmn')),
+        'pe_fund_net_qty': safe_int(data.get('pe_fund_ntby_vol')),
+        'pe_fund_net_amount': safe_int(data.get('pe_fund_ntby_tr_pbmn')),
+        'bank_net_qty': safe_int(data.get('bank_ntby_qty')),
+        'bank_net_amount': safe_int(data.get('bank_ntby_tr_pbmn')),
+        'insurance_net_qty': safe_int(data.get('insu_ntby_qty')),
+        'insurance_net_amount': safe_int(data.get('insu_ntby_tr_pbmn')),
+        'pension_fund_net_qty': safe_int(data.get('fund_ntby_qty')),
+        'pension_fund_net_amount': safe_int(data.get('fund_ntby_tr_pbmn')),
+    }
+```
+
+### 3.3 배치 처리
+
+**파일**: `main.py`
+
+```python
+def process_market_investor_trend():
+    """시장별 투자자 매매동향 수집 배치"""
+    targets = [
+        ("KSP", "0001"),  # 코스피 종합
+        ("KSQ", "1001"),  # 코스닥 종합
+        ("ETF", "T000"),  # ETF 전체
+    ]
+
+    for market_code, sector_code in targets:
+        data = collector.fetch_market_investor_trend(market_code, sector_code)
+        with mysql_db.atomic():
+            saver.upsert_market_investor_trend(data)
+```
+
+### 3.4 CLI 옵션
+
+```python
+parser.add_argument(
+    '--market-investor-trend',
+    action='store_true',
+    help='시장별 투자자 매매동향(시세) 수집'
+)
+```
+
+---
+
+## Phase 4: 배포 및 통합 테스트
+
+### 4.1 배포 순서
+
+1. **korea_investment_stock** PR merge 후 PyPI 배포
+   - PR을 master 브랜치에 merge
+   - GitHub Actions에서 `release.yml` workflow 수동 실행
+   - PyPI에 자동 배포됨
+2. **moneyflow.advenoh.pe.kr** DB 마이그레이션 실행
+   ```bash
+   cd moneyflow.advenoh.pe.kr/backend/db
+   ./liquibase.sh update
+   ```
+3. **stock-data-batch** 의존성 업데이트 및 배치 테스트
+   ```bash
+   python main.py --market-investor-trend
+   ```

--- a/docs/start/4_investor_time_prd.md
+++ b/docs/start/4_investor_time_prd.md
@@ -1,0 +1,133 @@
+# 시장별 투자자매매동향(시세) API 구현 PRD
+
+## 개요
+
+시장별 투자자매매동향(시세) API를 korea_investment_stock 라이브러리에 추가하고, stock-data-batch에서 해당 데이터를 DB에 저장하는 기능을 구현합니다.
+
+## API 정보
+
+| 항목 | 값 |
+|------|-----|
+| API명 | 시장별 투자자매매동향(시세) |
+| API ID | v1_국내주식-074 |
+| API 경로 | `/uapi/domestic-stock/v1/quotations/inquire-investor-time-by-market` |
+| TR ID | FHPTJ04030000 |
+| HTS 화면 | [0403] 시장별 시간동향 |
+| 모의투자 | 미지원 |
+
+---
+
+## 요청 파라미터
+
+| 파라미터 | 필수 | 설명 |
+|----------|------|------|
+| fid_input_iscd | Y | 시장구분 (KSP, KSQ 등) |
+| fid_input_iscd_2 | Y | 업종구분 (0001, 1001 등) |
+
+### 시장 코드 (market_code)
+
+| 코드 | 설명 |
+|------|------|
+| KSP | 코스피 |
+| KSQ | 코스닥 |
+| ETF | ETF |
+| ELW | ELW |
+| ETN | ETN |
+| K2I | 선물/콜옵션/풋옵션 |
+| 999 | 주식선물 |
+| MKI | 미니 |
+| WKM | 위클리(월) |
+| WKI | 위클리(목) |
+| KQI | 코스닥150 |
+
+### 업종 코드 (sector_code)
+
+| 코드 | 설명 |
+|------|------|
+| 0001 | 코스피 종합 |
+| 1001 | 코스닥 종합 |
+| F001 | 선물 |
+| OC01 | 콜옵션 |
+| OP01 | 풋옵션 |
+| T000 | ETF 전체 |
+| W000 | ELW 전체 |
+| E199 | ETN 전체 |
+
+---
+
+## 응답 데이터 필드
+
+### 투자자 유형별 접두사
+
+| 접두사 | 투자자 유형 |
+|--------|------------|
+| `frgn_*` | 외국인 |
+| `prsn_*` | 개인 |
+| `orgn_*` | 기관계 |
+| `scrt_*` | 증권 |
+| `ivtr_*` | 투자신탁 |
+| `pe_fund_*` | 사모펀드 |
+| `bank_*` | 은행 |
+| `insu_*` | 보험 |
+| `mrbn_*` | 종금 |
+| `fund_*` | 기금 |
+| `etc_orgt_*` | 기타단체 |
+| `etc_corp_*` | 기타법인 |
+
+### 세부 필드 (접미사)
+
+| 필드 접미사 | 설명 |
+|------------|------|
+| `_seln_vol` | 매도 거래량 |
+| `_shnu_vol` | 매수 거래량 |
+| `_ntby_qty` | 순매수 수량 |
+| `_seln_tr_pbmn` | 매도 거래 대금 |
+| `_shnu_tr_pbmn` | 매수 거래 대금 |
+| `_ntby_tr_pbmn` | 순매수 거래 대금 |
+
+---
+
+## 구현 범위
+
+### Phase 1: korea_investment_stock 라이브러리
+
+- `fetch_investor_trend_by_market(market_code, sector_code)` 메서드 추가
+- 시장/업종 코드 상수 추가 (`constants.py`)
+- 테스트 코드 작성
+- 버전 업데이트 (0.16.0)
+
+### Phase 2: DB 스키마 (moneyflow.advenoh.pe.kr)
+
+- Liquibase changelog 파일 작성
+- DB 마이그레이션 실행
+
+### Phase 3: stock-data-batch
+
+- `MarketInvestorTrend` DB 모델 추가
+- API 응답 매핑 함수
+- 데이터 수집/저장 함수
+- 배치 처리 함수
+- CLI 옵션 (`--market-investor-trend`)
+
+### Phase 4: 배포 및 통합 테스트
+
+- korea_investment_stock: PR merge 후 GitHub Actions `release.yml` 실행
+- moneyflow.advenoh.pe.kr: DB 마이그레이션 (Liquibase)
+- stock-data-batch: 의존성 업데이트 및 배치 테스트
+
+---
+
+## 수집 대상
+
+| 시장 | 업종 | 설명 |
+|------|------|------|
+| KSP | 0001 | 코스피 종합 |
+| KSQ | 1001 | 코스닥 종합 |
+| ETF | T000 | ETF 전체 |
+
+---
+
+## 관련 문서
+
+- [구현 문서](4_investor_time_implementation.md)
+- [TODO 체크리스트](4_investor_time_todo.md)

--- a/docs/start/4_investor_time_todo.md
+++ b/docs/start/4_investor_time_todo.md
@@ -1,0 +1,69 @@
+# 시장별 투자자매매동향(시세) API 구현 TODO
+
+## Phase 1: korea_investment_stock 라이브러리
+
+### API 구현
+
+- [x] `fetch_investor_trend_by_market()` 메서드 추가
+  - [x] API 경로 및 TR ID 설정
+  - [x] 요청 파라미터 (market_code, sector_code) 처리
+  - [x] `_request_with_token_refresh()` 사용
+
+### 상수 정의
+
+- [x] `constants.py`에 시장 코드 상수 추가 (`MARKET_INVESTOR_TREND_CODE`)
+- [x] `constants.py`에 업종 코드 상수 추가 (`SECTOR_CODE`)
+
+### 테스트
+
+- [x] `tests/test_investor_trend_by_market.py` 파일 생성
+- [x] 코스피 종합 조회 테스트 작성
+- [x] 코스닥 종합 조회 테스트 작성
+
+### 배포
+
+- [x] `pyproject.toml` 버전 업데이트 (setuptools_scm으로 Git 태그 사용)
+- [x] CHANGELOG.md 업데이트
+- [x] PR 생성 및 merge → PR #121: https://github.com/kenshin579/korea-investment-stock/pull/121
+- [x] PyPI 배포 (v0.16.1 릴리스 완료)
+
+---
+
+## Phase 2: DB 스키마 (moneyflow.advenoh.pe.kr)
+
+- [x] Liquibase changelog 파일 작성 (`8_create_market_investor_trend.sql`)
+  - PR #61: https://github.com/kenshin579/moneyflow.advenoh.pe.kr/pull/61
+- [x] DB 마이그레이션 실행 (`./liquibase.sh update-one`)
+
+---
+
+## Phase 3: stock-data-batch 수정
+
+### DB 모델
+
+- [x] `MarketInvestorTrend` 모델 클래스 추가
+
+### 데이터 수집
+
+- [x] `_map_market_investor_trend()` 매핑 함수 추가
+- [x] `fetch_market_investor_trend_data()` 수집 함수 추가
+- [x] `upsert_market_investor_trend()` 저장 함수 추가
+
+### 배치 처리
+
+- [x] `process_market_investor_trend()` 배치 함수 추가
+- [x] CLI 옵션 `--market-investor-trend` 추가
+
+### 의존성
+
+- [x] `pyproject.toml`에서 `korea-investment-stock>=0.16.1` 업데이트
+- PR #70: https://github.com/kenshin579/stock-data-batch/pull/70
+
+---
+
+## Phase 4: 배포 및 통합 테스트
+
+- [x] korea_investment_stock PR merge 및 `release.yml` 실행 (v0.16.1)
+- [x] moneyflow.advenoh.pe.kr DB 마이그레이션 실행
+- [ ] stock-data-batch 배치 테스트 (`python main.py --market-investor-trend`)
+- [ ] DB 저장 결과 확인


### PR DESCRIPTION
## Summary

Add documentation files for the market investor trend API feature (v0.16.1):

- `docs/start/3_investor_api.md` - Investor API overview
- `docs/start/4_investor_time_prd.md` - PRD for market investor trend
- `docs/start/4_investor_time_implementation.md` - Implementation guide
- `docs/start/4_investor_time_todo.md` - TODO checklist with PR links

## Related PRs

- korea-investment-stock: PR #121 (v0.16.1 released)
- moneyflow.advenoh.pe.kr: PR #61 (DB schema)
- stock-data-batch: PR #70 (batch implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)