### PR TITLE
fix: 토큰 파일 env 배선 + 무효 토큰(EGW00121) 자동 refresh

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -3,11 +3,14 @@ package kis
 import (
 	"context"
 	"net/http"
+	"path/filepath"
 	"testing"
 
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kenshin579/korea-investment-stock/internal/token"
 )
 
 func TestNewClient_RequiresAllParams(t *testing.T) {
@@ -51,8 +54,11 @@ func TestNewClient_TokenIssue(t *testing.T) {
 			"access_token_token_expired": "2099-12-31 23:59:59"
 		}`))
 
+	// 격리된 빈 토큰 저장소 주입 — 사용자 실제 캐시(~/.cache/kis/token.json)에
+	// 의존하지 않고 mock 발급 경로를 타도록 한다.
 	c, err := NewClient("k", "s", "acc",
 		WithHTTPClient(&http.Client{Transport: httpmock.DefaultTransport}),
+		WithTokenStorage(token.NewFileStorage(filepath.Join(t.TempDir(), "tok.json"))),
 	)
 	require.NoError(t, err)
 	tok, err := c.IssueAccessToken(context.Background())

--- a/from_env.go
+++ b/from_env.go
@@ -1,6 +1,28 @@
 package kis
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/kenshin579/korea-investment-stock/internal/token"
+)
+
+// storageFromConfig 는 Config 의 토큰 저장소 설정을 token.Storage 로 변환한다.
+//   - redis: TOKEN_STORAGE=redis + REDIS_URL 지정 시.
+//   - file:  TOKEN_FILE 지정 시 해당 경로의 FileStorage.
+//   - 그 외: nil (NewClient 가 기본 FileStorage(~/.cache/kis/token.json) 사용).
+func storageFromConfig(cfg *Config) (token.Storage, error) {
+	if cfg.TokenStorage == "redis" && cfg.RedisURL != "" {
+		s, err := newRedisStorage(cfg.RedisURL, cfg.RedisPassword)
+		if err != nil {
+			return nil, fmt.Errorf("kis: redis storage: %w", err)
+		}
+		return s, nil
+	}
+	if cfg.TokenFile != "" {
+		return token.NewFileStorage(cfg.TokenFile), nil
+	}
+	return nil, nil
+}
 
 // NewClientFromEnv 는 KOREA_INVESTMENT_* 환경변수에서 credentials/설정 자동 감지 후 Client 생성.
 // 추가 옵션은 functional options 로 override 가능.
@@ -28,11 +50,11 @@ func newFromConfig(cfg *Config, opts ...Option) (*Client, error) {
 		baseOpts = append(baseOpts, WithMasterCacheDir(cfg.MasterCacheDir))
 	}
 
-	if cfg.TokenStorage == "redis" && cfg.RedisURL != "" {
-		s, err := newRedisStorage(cfg.RedisURL, cfg.RedisPassword)
-		if err != nil {
-			return nil, fmt.Errorf("kis: redis storage: %w", err)
-		}
+	s, err := storageFromConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if s != nil {
 		baseOpts = append(baseOpts, WithTokenStorage(s))
 	}
 

--- a/from_env_test.go
+++ b/from_env_test.go
@@ -1,12 +1,18 @@
 package kis
 
 import (
+	"context"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kenshin579/korea-investment-stock/internal/token"
 )
 
 func TestNewClientFromEnv_Success(t *testing.T) {
@@ -30,4 +36,30 @@ func TestNewClientFromEnv_MissingEnv(t *testing.T) {
 	t.Setenv("KOREA_INVESTMENT_ACCOUNT_NO", "x")
 	_, err := NewClientFromEnv()
 	require.Error(t, err)
+}
+
+// TOKEN_FILE 이 지정되면 그 경로의 FileStorage 가 쓰여야 한다.
+// (회귀: 과거 from_env 가 cfg.TokenFile 을 무시해 항상 기본 경로만 사용했다.)
+func TestStorageFromConfig_TokenFileHonored(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tok.json")
+
+	s, err := storageFromConfig(&Config{TokenFile: path})
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	err = s.Save(context.Background(), &token.AccessToken{
+		Value: "abc", TokenType: "Bearer", ExpiresAt: time.Now().Add(time.Hour),
+	})
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(path)
+	require.NoError(t, statErr, "토큰이 설정한 TokenFile 경로에 저장되어야 함")
+}
+
+// token_file/redis 미지정이면 nil → NewClient 기본 파일 저장소에 위임.
+func TestStorageFromConfig_DefaultNil(t *testing.T) {
+	s, err := storageFromConfig(&Config{})
+	require.NoError(t, err)
+	require.Nil(t, s)
 }

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -153,8 +153,8 @@ func (c *Client) Do(ctx context.Context, req *Request) (*Response, error) {
 		return nil, err
 	}
 
-	// 토큰 만료 → 1회 재발급 후 재시도
-	if resp != nil && isTokenExpired(resp) {
+	// 토큰 무효/만료 → 1회 재발급 후 재시도
+	if resp != nil && isTokenError(resp) {
 		newBearer, refErr := c.cfg.TokenMgr.Refresh(ctx)
 		if refErr != nil {
 			return nil, refErr
@@ -210,6 +210,19 @@ func (c *Client) send(ctx context.Context, req *Request, bearer string) (*Respon
 			continue
 		}
 
+		// 한투는 비즈니스 오류(토큰 무효 EGW00121 / 만료 EGW00123 등)도 HTTP 500 +
+		// JSON body 로 반환하는 경우가 있다. body 가 한투 응답(rt_cd 포함)이면 상태코드와
+		// 무관하게 그대로 반환해 Do() 의 토큰 refresh / APIError 처리에 맡긴다.
+		// (그렇지 않으면 결정적 토큰 오류를 일시적 5xx 로 오인해 헛되이 재시도한다.)
+		raw := httpResp.Body()
+		var resp Response
+		jsonErr := json.Unmarshal(raw, &resp)
+		if jsonErr == nil && resp.RtCode != "" {
+			resp.Raw = raw
+			return &resp, nil
+		}
+
+		// 한투 JSON 이 아닌 5xx/429 → 일시적 전송 오류로 보고 재시도.
 		if httpResp.StatusCode() >= 500 || httpResp.StatusCode() == http.StatusTooManyRequests {
 			lastHTTPErr = fmt.Errorf("HTTP %d", httpResp.StatusCode())
 			if attempt == c.cfg.Retries {
@@ -225,10 +238,9 @@ func (c *Client) send(ctx context.Context, req *Request, bearer string) (*Respon
 			continue
 		}
 
-		raw := httpResp.Body()
-		var resp Response
-		if err := json.Unmarshal(raw, &resp); err != nil {
-			return nil, fmt.Errorf("kis: parse: %w (body=%s)", err, string(raw))
+		// 2xx 인데 한투 JSON 파싱 실패.
+		if jsonErr != nil {
+			return nil, fmt.Errorf("kis: parse: %w (body=%s)", jsonErr, string(raw))
 		}
 		resp.Raw = raw
 		return &resp, nil
@@ -236,9 +248,17 @@ func (c *Client) send(ctx context.Context, req *Request, bearer string) (*Respon
 	return nil, errors.New("unreachable")
 }
 
-func isTokenExpired(r *Response) bool {
-	// 한투는 만료 시 msg_cd 가 EGW00123 또는 메시지에 "기간이 만료된 token" 포함.
-	return r.MsgCode == "EGW00123" || strings.Contains(r.Msg1, "기간이 만료된 token")
+// isTokenError 는 응답이 토큰 재발급으로 회복 가능한 인증 오류인지 판정한다.
+// 한투는 두 가지를 구분한다(둘 다 refresh 로 회복):
+//   - 만료: msg_cd EGW00123 또는 "기간이 만료된 token" (HTTP 200 으로 오기도 함)
+//   - 무효: msg_cd EGW00121 또는 "유효하지 않은 token" (HTTP 500 으로 오기도 함)
+func isTokenError(r *Response) bool {
+	switch r.MsgCode {
+	case "EGW00123", "EGW00121":
+		return true
+	}
+	return strings.Contains(r.Msg1, "기간이 만료된 token") ||
+		strings.Contains(r.Msg1, "유효하지 않은 token")
 }
 
 func backoff(attempt int) time.Duration {

--- a/internal/httpclient/client_test.go
+++ b/internal/httpclient/client_test.go
@@ -124,6 +124,32 @@ func TestClient_Do_Retry5xx(t *testing.T) {
 	assert.Equal(t, int64(2), calls.Load(), "5xx → retry")
 }
 
+// 실제 한투는 "유효하지 않은 token"(EGW00121) 을 HTTP 500 + JSON body 로 반환한다.
+// send() 가 이를 단순 5xx 로 보고 blind retry 하면 refresh 기회를 잃는다.
+// → 토큰 오류 body 면 1회 refresh 후 재시도해야 한다 (blind 3회 재시도 X).
+func TestClient_Do_InvalidTokenHTTP500AutoRefresh(t *testing.T) {
+	tm := &stubTokenMgr{bearer: "Bearer T"}
+	c := newTestClient(t, tm)
+	calls := atomic.Int64{}
+	httpmock.RegisterResponder(http.MethodGet, "=~/inquire-price",
+		func(req *http.Request) (*http.Response, error) {
+			calls.Add(1)
+			if req.Header.Get("Authorization") == "Bearer T-refreshed" {
+				return httpmock.NewStringResponse(200, `{"rt_cd":"0","msg_cd":"OK","msg1":"ok"}`), nil
+			}
+			// 오래된 토큰 → 한투가 HTTP 500 + EGW00121
+			return httpmock.NewStringResponse(500, `{"rt_cd":"1","msg_cd":"EGW00121","msg1":"유효하지 않은 token 입니다."}`), nil
+		})
+
+	resp, err := c.Do(context.Background(), &Request{
+		Method: http.MethodGet, Path: "/inquire-price", TrID: "FHKST01010100",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "0", resp.RtCode)
+	assert.Equal(t, int64(2), calls.Load(), "500 invalid-token → refresh 후 1회 재시도 (blind 5xx 재시도 아님)")
+	assert.GreaterOrEqual(t, tm.calls.Load(), int64(2), "token Get + Refresh 모두 호출")
+}
+
 func TestClient_Do_TokenError(t *testing.T) {
 	tm := &errorTokenMgr{err: errors.New("oauth down")}
 	c := newTestClient(t, tm)


### PR DESCRIPTION
## 배경

KIS 토큰 캐시(`~/.cache/kis/token.json`)에 오염/만료된 토큰이 있으면 **모든 API 호출이 HTTP 500(EGW00121 "유효하지 않은 token")** 을 받았고, `send()` 가 이를 일시적 5xx 로 오인해 **종목마다 3회씩 헛재시도** → 사실상 무한 retry 후 실패하는 증상이 발견되었습니다. (auto-trading-journal 의 bizcat 섹터 조회가 이 경로에 걸려 멈춤)

## 변경

### Fix #1 — `KOREA_INVESTMENT_TOKEN_FILE` 배선
- `from_env` 가 `cfg.TokenFile` 을 무시하고 항상 기본 경로만 쓰던 회귀를 수정.
- `storageFromConfig()` 헬퍼로 redis / file / 기본(nil) 분기를 명시. `TokenFile` 지정 시 해당 경로의 `FileStorage` 사용 → 도구별 토큰 격리 가능.

### Fix #2 — 무효/만료 토큰이면 blind 재시도 대신 1회 refresh
- `send()` 가 응답 body 를 먼저 파싱해 한투 응답(`rt_cd` 포함)이면 **HTTP 상태코드와 무관하게 반환** → `Do()` 의 토큰 refresh / APIError 처리에 위임.
- `isTokenExpired` → `isTokenError` 로 확장: `EGW00121`(무효) + `EGW00123`(만료), `"유효하지 않은 token"` / `"기간이 만료된 token"` 메시지 모두 인식.

### 기타
- `TestNewClient_TokenIssue` 가 사용자 실제 캐시에 의존하던 격리 결함 수정(임시 `FileStorage` 주입).

## Test plan
- [x] 신규 `TestClient_Do_InvalidTokenHTTP500AutoRefresh` (500+EGW00121 → 1회 refresh 후 성공, blind 재시도 아님)
- [x] 신규 `TestStorageFromConfig_TokenFileHonored` / `_DefaultNil`
- [x] 기존 `TestClient_Do_Retry5xx` / `TestClient_Do_TokenExpiredAutoRetry` 통과
- [x] `go build ./...` / `go vet ./...` / `go test ./...` 전체 통과